### PR TITLE
Fix same state command interfaces

### DIFF
--- a/beckhoff_hardware_interface/include/beckhoff_hardware_interface/beckhoff_system.hpp
+++ b/beckhoff_hardware_interface/include/beckhoff_hardware_interface/beckhoff_system.hpp
@@ -13,6 +13,7 @@
 
 #include <string>
 #include <vector>
+#include <limits>
 
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/handle.hpp"
@@ -44,6 +45,9 @@ struct ADSDataLayout {
 
     // for mapping to ros2_control
     size_t      offset_in_ros2_control;    // Starting index in hw_states_ or hw_commands_
+
+    // If we have an identically named command and state interface, in case there are no new commands to be sent to the robot, we want to use the value read in the state interface for the next request.
+    size_t      offset_in_ros2_control_state_ = std::numeric_limits<size_t>::max();
 
     // for unpacking sum read response  [Err1_ULONG,...,ErrN_ULONG | Data1_bytes,...,DataN_bytes]
     size_t      offset_in_read_response_error;    // Byte offset where this item's ULONG error code starts.
@@ -92,9 +96,7 @@ private:
     std::shared_ptr<rclcpp::Clock> logging_throttle_clock_;
 
     std::vector<double> hw_commands_;
-    std::vector<double> hw_commands_old_;  // keep old commands to detect changes
     std::vector<double> hw_states_;
-    bool write_always_ = false; // If true, all command values are written to PLC on each write() call. If false, only changed values are written.
 
     // ========= PLC ==============================
 

--- a/beckhoff_hardware_interface/src/beckhoff_system.cpp
+++ b/beckhoff_hardware_interface/src/beckhoff_system.cpp
@@ -684,15 +684,6 @@ bool BeckhoffSystem::configure_ads_device()
         return false;
     }
 
-    auto it = params.find("write_always");
-    if (it != params.end())
-    {
-        write_always_ = hardware_interface::parse_bool(it->second);
-    }
-    else
-    {
-        write_always_ = false;
-    }
     return true;
 }
 

--- a/beckhoff_hardware_interface/src/beckhoff_system.cpp
+++ b/beckhoff_hardware_interface/src/beckhoff_system.cpp
@@ -241,6 +241,7 @@ std::vector<hardware_interface::CommandInterface> BeckhoffSystem::export_command
     std::vector<hardware_interface::CommandInterface> command_interfaces;
     command_interfaces.reserve(num_command_interfaces);
     hw_commands_.resize(num_command_interfaces, std::numeric_limits<double>::quiet_NaN());
+    hw_commands_old_.resize(num_command_interfaces, std::numeric_limits<double>::quiet_NaN());
 
     // Reserve worst-case scenario for layouts (each interface targets a different PLC symbol)
     ads_item_layouts_write_.clear();
@@ -489,17 +490,26 @@ hardware_interface::return_type BeckhoffSystem::write(
 
         // TODO: performance - Hoist the switch/case above for loop?
         for (size_t k = 0; k < item_layout.num_elements; ++k) {
-            const double val = hw_commands_[ item_layout.offset_in_ros2_control + k ];
+            double val = hw_commands_[ item_layout.offset_in_ros2_control + k ];
 
             bool value_not_ok = std::isnan(val);
 
             if (not write_always_) {
               const double old_val = hw_commands_old_[ item_layout.offset_in_ros2_control + k ];
-              value_not_ok |= (val == old_val);
+              value_not_ok = value_not_ok || (val == old_val);
               hw_commands_old_[ item_layout.offset_in_ros2_control + k ] = val;
             }
             if (value_not_ok) {
-                continue;
+                auto it = std::find_if(ads_item_layouts_read_.begin(), ads_item_layouts_read_.end(),
+                             [&](const ADSDataLayout& layout) { return layout.plc_name_symbolic == item_layout.plc_name_symbolic; });
+                if (it != ads_item_layouts_read_.end())
+                {
+                    val = hw_states_[ it->offset_in_ros2_control + k ];
+                }
+                else
+                {
+                    continue;
+                }
             }
 
             uint8_t* ptr_write_buffer_destination_current = ptr_write_buffer_destination + (k * item_layout.plc_element_byte_size);


### PR DESCRIPTION
### Ensure command value is only written once. Otherwise:

* if we have a state value of the same name, write that. This allows for changes from some other source to the PLC var to be retained and appear on state interface on ros side.
* if the state value exists, and is also NaN, don't update the buffer, old value remains to be written
* if the command is NaN, and no fallback exists, don't update the buffer, old value remains to be written
* will work the same for each element of ARRAY PLC vars.