### PR TITLE
Update to jazzy organized

### DIFF
--- a/PLC-TestProject/Untitled1/POUs/MAIN.TcPOU
+++ b/PLC-TestProject/Untitled1/POUs/MAIN.TcPOU
@@ -13,17 +13,23 @@ VAR
 	// --- Command Interfaces (Inputs from ROS) ---
 	joggingEnabled	: BOOL;		// Mapped to: <command_interface name="joggingEnabled">
 	myRobotMode			: UDINT;	// Mapped to: <command_interface name="myRobotMode">
+	motionType      : USINT;      // Mapped to: <command_interface name="motionType">
+
 	
 	// Mapped to: <state_interface name="commandPos">, where n is the element index in this array
 	commandPos		: ARRAY[0..1] OF BOOL;
 
 	// --- State Interfaces (Outputs to ROS) ---
 	statusError	: BOOL;		// Mapped to: <state_interface name="statusError">
-	batteryVoltage	: LREAL;		// Mapped to: <state_interface name="batteryVoltage">
+	batteryVoltage	: REAL;		// Mapped to: <state_interface name="batteryVoltage">
 	
 	// Mapped to: <state_interface name="currentPos_n">, where n is the element index in this array
 	currentPos		: ARRAY[0..1] OF LREAL; 
-
+	
+	pickCount         : UINT; // Mapped to: <state_interface name="pickCount">
+	ledMap : BYTE; // Mapped to: <state_interface name="ledMap"> where Bit 0: Power On ; Bit 1: Robot moving ; Bit 2: At Position ; Bit 3: Error. The other bits are unused 
+	currentTemperature : INT; // Mapped to: <state_interface name="currentTemperature">
+	
 	(*
 	================================================================
 	Internal Helper Variables
@@ -33,6 +39,8 @@ VAR
 	_counter		: DINT := 0;
 	_angle			: LREAL;
 
+	_atPosition: BOOL; // The robot is placed at the correct position to pick an item
+	
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -42,24 +50,78 @@ _counter := _counter + 1;
 // 2. Make the error status flag toggle on and off.
 IF (_counter MOD 1000) = 0 THEN
 	statusError := NOT statusError;
+	_atPosition := NOT _atPosition;
 END_IF;
 
 // 3. Simulate a fluctuating battery voltage using a sine wave.
-_angle := DINT_TO_LREAL(_counter) * 0.01;
-batteryVoltage := 24.0 + (SIN(_angle) * 0.5);
+_angle := DINT_TO_REAL(_counter) * 0.01;
+batteryVoltage := LREAL_TO_REAL(24.0 + (SIN(_angle) * 0.5));
 
-// 4. Simulate changing joint positions.
-currentPos[0] := currentPos[0] + 0.0005;
-currentPos[1] := COS(_angle * 2.0);]]></ST>
+// 4. Simulate changing joint positions based on motionType
+CASE motionType OF
+	0 : // Jogging motion : increment values 
+		IF joggingEnabled THEN
+			currentPos[0] := currentPos[0] + 0.0005;
+			currentPos[1] := currentPos[1] + 0.0005;
+		END_IF
+		
+	1: // Simulate robot movement to pick an item
+	 	currentPos[0] := SIN(_angle * 2.0);
+		currentPos[1] := COS(_angle * 2.0);
+
+		IF _atPosition THEN
+				pickCount := pickCount + 1; 
+		END_IF;
+
+	ELSE // motionType code invalid : error
+		statusError := TRUE;
+END_CASE
+
+//5. Simulate varying temperature between [20°,30°]
+currentTemperature := LREAL_TO_INT(25 + 5 * SIN(_angle * 0.1));
+
+// 6. Map the led lights into the variable ledMap
+
+// LED 0 – Power On
+ledMap.0 := TRUE;
+
+// LED 1 – Robot Moving
+ledMap.1 := joggingEnabled OR (motionType = 1);
+
+// LED 2 – Ready to pick item
+ledMap.2 := _atPosition;
+
+// LED 3 – Error
+ledMap.3 := statusError;]]></ST>
     </Implementation>
     <LineIds Name="MAIN">
       <LineId Id="78" Count="3" />
       <LineId Id="85" Count="0" />
-      <LineId Id="131" Count="2" />
+      <LineId Id="131" Count="0" />
+      <LineId Id="201" Count="0" />
+      <LineId Id="132" Count="1" />
       <LineId Id="86" Count="0" />
       <LineId Id="88" Count="3" />
-      <LineId Id="93" Count="0" />
-      <LineId Id="96" Count="0" />
+      <LineId Id="172" Count="1" />
+      <LineId Id="175" Count="1" />
+      <LineId Id="178" Count="0" />
+      <LineId Id="177" Count="0" />
+      <LineId Id="207" Count="0" />
+      <LineId Id="182" Count="0" />
+      <LineId Id="184" Count="0" />
+      <LineId Id="186" Count="0" />
+      <LineId Id="188" Count="1" />
+      <LineId Id="191" Count="0" />
+      <LineId Id="196" Count="2" />
+      <LineId Id="200" Count="0" />
+      <LineId Id="174" Count="0" />
+      <LineId Id="225" Count="0" />
+      <LineId Id="209" Count="0" />
+      <LineId Id="227" Count="0" />
+      <LineId Id="224" Count="0" />
+      <LineId Id="208" Count="0" />
+      <LineId Id="223" Count="0" />
+      <LineId Id="212" Count="10" />
     </LineIds>
   </POU>
 </TcPlcObject>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # beckhoff_ads_hardware_interface for ROS 2
 Copyright (c) 2025, b-robotized. All rights reserved.
-Author: Nikola Banovic
+Author: Nikola Banovic Contributor: Hajar Bartakh
 
 This package provides a `ros2_control` **SystemInterface** for communicating with Beckhoff TwinCAT PLCs. It acts as a transport layer, allowing `ros2_control` controllers to read from and write to PLC variables (e.g., joint states, GPIOs, sensor values) over the network.
 
@@ -118,6 +118,18 @@ ros2 topic echo /controller_manager/introspection_data/full
 ## Troubleshooting
 
 For troubleshooting network connection with TwinCAT 3 XAE, refer to [the documentation](https://download.beckhoff.com/download/document/automation/twincat3/TwinCAT_3_ADS_INTRO_EN.pdf), especially chapters 7. and 8.
+
+*Please note that the two following issues were encountered while running the TwinCAT 3 XAE example project on a Windows Virtual Machine.*
+
+### TwinCAT 3 XAE Crash on Windows 11 VM 
+The issue occurs when switching off `Run Mode` inside `TwinCAT 3 XAE`. `TwinCAT`crashes afterwards and reboots the VM.   
+The core isolation was responsible for the bug. Isolated cores can be removed from the project's `Real time Settings`. 
+
+### ADS Connection Failure 
+The ADS connection may be [refused](https://epics.cosylab.com/documentation/adsDriver/troubleshooting/index.html#ioc-fails-to-connect-with-read-frame-failed-with-error-connection-reset-by-peer-errors) even though both the PLC and the host machine can ping each other.   
+The ADS router does not seem to recognize the physical IP address of the host. The host-side **virtual IP address** should be the one used instead for the route in `TwinCAT 3 XAE` and inside the `URDF`.    
+In our case for example, it corresponds to the interface `virbr0`.
+
 
 # Future Plans
 Feel free to contribute on any of these!

--- a/beckhoff_ads_bringup/launch/beckhoff_bot.launch.xml
+++ b/beckhoff_ads_bringup/launch/beckhoff_bot.launch.xml
@@ -17,7 +17,7 @@ Authors: Nikola Banovic Dr. Denis
 -->
 
 <launch>
-    <arg name="mock_hardware" default="true" />
+    <arg name="mock_hardware" default="false" />
     <arg name="mock_sensor_commands" default="false"/>
 
     <let name="robot_description_content" value="$(command '$(find-exec xacro) $(find-pkg-share beckhoff_ads_bringup)/urdf/beckhoff_bot.urdf.xacro mock_hardware:=$(var mock_hardware) mock_sensor_commands:=$(var mock_sensor_commands)')"/>
@@ -34,4 +34,3 @@ Authors: Nikola Banovic Dr. Denis
     </node>
 
 </launch>
-

--- a/beckhoff_ads_bringup/urdf/beckhoff_bot/beckhoff_bot_macro.ros2_control.xacro
+++ b/beckhoff_ads_bringup/urdf/beckhoff_bot/beckhoff_bot_macro.ros2_control.xacro
@@ -24,12 +24,6 @@
             </xacro:unless>
         </hardware>
 
-        <!-- IMPORTANT!
-        As it is currently implemented, multiple interfaces targeting different indices of a PLC variable of type ARRAY[x]
-        MUST be defined in ascending order starting at 0! (0, 1, 2...).
-        Declaring indices descending or out-of-order (2, 1, 0) causes mismatch between hw_states/command buffers and byte buffers received from PLC
-        -->
-
         <!-- These interfaces can be declared for any component - joint, gpio or sensor -->
 
         <gpio name="robot_io">

--- a/beckhoff_ads_bringup/urdf/beckhoff_bot/beckhoff_bot_macro.ros2_control.xacro
+++ b/beckhoff_ads_bringup/urdf/beckhoff_bot/beckhoff_bot_macro.ros2_control.xacro
@@ -25,30 +25,36 @@
         </hardware>
 
         <!-- IMPORTANT!
-        As it is currently implemented, multiple interfaces targeting different indices of a PLC variable of type ARRAY[x] 
-        MUST be defined in ascending order starting at 0! (0, 1, 2...). 
+        As it is currently implemented, multiple interfaces targeting different indices of a PLC variable of type ARRAY[x]
+        MUST be defined in ascending order starting at 0! (0, 1, 2...).
         Declaring indices descending or out-of-order (2, 1, 0) causes mismatch between hw_states/command buffers and byte buffers received from PLC
         -->
-        
+
         <!-- These interfaces can be declared for any component - joint, gpio or sensor -->
 
         <gpio name="robot_io">
             <xacro:command_interface_PLC name="joggingEnabled" PLC_symbol="MAIN.joggingEnabled" PLC_type="BOOL" initial_value="1"/>
             <xacro:command_interface_PLC name="myRobotMode" PLC_symbol="MAIN.myRobotMode" PLC_type="UDINT" initial_value="5"/>
+            <xacro:command_interface_PLC name="motionType" PLC_symbol="MAIN.motionType" PLC_type="USINT" initial_value="1"/>
             <xacro:command_interface_PLC name="commandPos_0" PLC_symbol="MAIN.commandPos" PLC_type="BOOL" n_elements="2" index="0" initial_value="1"/>
-            <xacro:command_interface_PLC name="commandPos_1" PLC_symbol="MAIN.commandPos" PLC_type="BOOL" n_elements="2" index="1" initial_value="1"/>            
+            <xacro:command_interface_PLC name="commandPos_1" PLC_symbol="MAIN.commandPos" PLC_type="BOOL" n_elements="2" index="1" initial_value="1"/>
         </gpio>
         <sensor name="robot_sensor">
             <xacro:state_interface_PLC name="statusError" PLC_symbol="MAIN.statusError" PLC_type="BOOL"/>
             <xacro:state_interface_PLC name="batteryVoltage" PLC_symbol="MAIN.batteryVoltage" PLC_type="REAL"/>
             <xacro:state_interface_PLC name="currentPos_0" PLC_symbol="MAIN.currentPos" PLC_type="LREAL" n_elements="2" index="0" />
             <xacro:state_interface_PLC name="currentPos_1" PLC_symbol="MAIN.currentPos" PLC_type="LREAL" n_elements="2" index="1" />
+            <xacro:state_interface_PLC name="pickCount" PLC_symbol="MAIN.pickCount" PLC_type="UINT" />
+            <xacro:state_interface_PLC name="currentTemperature" PLC_symbol="MAIN.currentTemperature" PLC_type="INT" />
+            <xacro:state_interface_PLC name="ledMap" PLC_symbol="MAIN.ledMap" PLC_type="BYTE"/>
+
 
             <!-- In this example, these mirror command interfaces, so we can monitor if the variables are set correctly. -->
             <xacro:state_interface_PLC name="joggingEnabled" PLC_symbol="MAIN.joggingEnabled" PLC_type="BOOL" />
             <xacro:state_interface_PLC name="myRobotMode" PLC_symbol="MAIN.myRobotMode" PLC_type="UDINT"/>
+            <xacro:state_interface_PLC name="motionType" PLC_symbol="MAIN.motionType" PLC_type="UDINT"/>
             <xacro:state_interface_PLC name="commandPos_0" PLC_symbol="MAIN.commandPos" PLC_type="BOOL" n_elements="2" index="0" />
-            <xacro:state_interface_PLC name="commandPos_1" PLC_symbol="MAIN.commandPos" PLC_type="BOOL" n_elements="2" index="1" />     
+            <xacro:state_interface_PLC name="commandPos_1" PLC_symbol="MAIN.commandPos" PLC_type="BOOL" n_elements="2" index="1" />
         </sensor>
 
         </ros2_control>

--- a/beckhoff_ads_hardware_interface/include/beckhoff_ads_hardware_interface/beckhoff_ads_hardware_interface.hpp
+++ b/beckhoff_ads_hardware_interface/include/beckhoff_ads_hardware_interface/beckhoff_ads_hardware_interface.hpp
@@ -7,6 +7,7 @@
 // The file is considered confidential.
 
 // Author: Nikola Banovic
+// Contributor: Hajar Bartakh
 
 #ifndef beckhoff_ads_hardware_interface__BECKHOFF_SYSTEM_HPP_
 #define beckhoff_ads_hardware_interface__BECKHOFF_SYSTEM_HPP_
@@ -80,18 +81,18 @@ namespace beckhoff_ads_hardware_interface
 
   struct ReadInstruction
   {
-    size_t read_error_code_offset;
-    size_t buffer_offset;
+    size_t read_buffer_offset_error_code;
+    size_t read_buffer_offset_data;
     PLCType plc_type;
-    std::string interface_name;
+    std::string state_interface_name;
   };
 
   struct WriteInstruction
   {
-    size_t buffer_offset;
+    size_t write_buffer_offset_data;
     PLCType plc_type;
-    std::string interface_name;
-    std::string fallback_name; // The state interface name corresponding to the current command interface name
+    std::string command_interface_name;
+    std::string fallback_state_interface_name; // The state interface name corresponding to the current command interface name
   };
 
   class BeckhoffADSHardwareInterface : public hardware_interface::SystemInterface

--- a/beckhoff_ads_hardware_interface/include/beckhoff_ads_hardware_interface/beckhoff_ads_hardware_interface.hpp
+++ b/beckhoff_ads_hardware_interface/include/beckhoff_ads_hardware_interface/beckhoff_ads_hardware_interface.hpp
@@ -27,81 +27,92 @@
 namespace beckhoff_ads_hardware_interface
 {
 
-enum class PLCType
-{
+  enum class PLCType
+  {
     // Using enum instead of raw strings for faster iterations in read/write
-    UNKNOWN, BOOL, LREAL, REAL, UDINT, DINT, INT, UINT, SINT, USINT, BYTE, STRING,
-};
+    UNKNOWN,
+    BOOL,
+    LREAL,
+    REAL,
+    UDINT,
+    DINT,
+    INT,
+    UINT,
+    SINT,
+    USINT,
+    BYTE,
+    STRING,
+  };
 
-// Describes each PLC item (array or single variable) for polling via sum commands.
-struct ADSDataLayout {
+  // Describes each PLC item (array or single variable) for polling via sum commands.
+  struct ADSDataLayout
+  {
     // Configured from yaml
-    std::string plc_name_symbolic;     // e.g., "MAIN.Joint_Pos_State". Used to get the handle.
-    PLCType     plc_type;
-    uint32_t    ads_handle;          // PLC Handle for the symbolic name. Not using AdsHandle, as we don't need a shared ptr, just a value to paste in the message
+    std::string plc_name_symbolic; // e.g., "MAIN.Joint_Pos_State". Used to get the handle.
+    PLCType plc_type;
+    uint32_t ads_handle; // PLC Handle for the symbolic name. Not using AdsHandle, as we don't need a shared ptr, just a value to paste in the message
 
-    size_t      num_elements;        // 6 for LREAL[6], 1 for single LREAL/BOOL etc.
-    size_t      plc_element_byte_size; // byte size of ONE element on PLC (e.g., 8 for LREAL, 1 for BOOL).
-
-    // for mapping to ros2_control
-    size_t      offset_in_ros2_control;    // Starting index in hw_states_ or hw_commands_
+    size_t num_elements;          // 6 for LREAL[6], 1 for single LREAL/BOOL etc.
+    size_t plc_element_byte_size; // byte size of ONE element on PLC (e.g., 8 for LREAL, 1 for BOOL).
 
     // If we have an identically named command and state interface, in case there are no new commands to be sent to the robot, we want to use the value read in the state interface for the next request.
-    size_t      offset_in_ros2_control_state_ = std::numeric_limits<size_t>::max();
+    // for mapping the ros2 state interfaces names to the corresponding command interfaces names <command_interface_name, state_interface_name>
+    std::map<std::string, std::string> state_command_interfaces_map_;
 
     // for unpacking sum read response  [Err1_ULONG,...,ErrN_ULONG | Data1_bytes,...,DataN_bytes]
-    size_t      offset_in_read_response_error;    // Byte offset where this item's ULONG error code starts.
-    size_t      offset_in_read_response_data;     // Byte offset where this item's data starts.
+    size_t offset_in_read_response_error; // Byte offset where this item's ULONG error code starts.
+    size_t offset_in_read_response_data;  // Byte offset where this item's data starts.
 
     // for packing sum write response [ADS_ITEM_REQ_HEADER_1,...,ADS_ITEM_REQ_HEADER_N | Data1_bytes,...,DataN_bytes]
-    size_t      offset_in_write_request_data;     // Byte offset where this item's data starts.
-};
+    size_t offset_in_write_request_data; // Byte offset where this item's data starts.
 
-// Packed header for sum read/write request item headers
-typedef struct {
-    uint32_t indexGroup;  // ADSIGRP_SYM_VALBYHND
-    uint32_t indexOffset; // The ADS Handle
-    uint32_t NumBytesData;      // total num of bytes in this data section
-} ADS_ITEM_REQ_HEADER;
+    // For interfaces targeting the same PLC symbol, store all their names with their corresponding index inside a map. This will be useful when calling thr ROS2 set_state and set_command functions.
+    std::map<size_t, std::string> ros2_interfaces_;
+  };
 
-class BeckhoffADSHardwareInterface : public hardware_interface::SystemInterface
-{
-public:
-    hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareComponentParams & params);
+  // Packed header for sum read/write request item headers
+  typedef struct
+  {
+    uint32_t indexGroup;   // ADSIGRP_SYM_VALBYHND
+    uint32_t indexOffset;  // The ADS Handle
+    uint32_t NumBytesData; // total num of bytes in this data section
+  } ADS_ITEM_REQ_HEADER;
+
+  class BeckhoffADSHardwareInterface : public hardware_interface::SystemInterface
+  {
+  public:
+    hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareComponentParams &params);
 
     hardware_interface::CallbackReturn on_configure(
-      const rclcpp_lifecycle::State & previous_state) override;
+        const rclcpp_lifecycle::State &previous_state) override;
 
-    std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+    // std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
 
-    std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+    // std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
 
     hardware_interface::CallbackReturn on_activate(
-      const rclcpp_lifecycle::State & previous_state) override;
+        const rclcpp_lifecycle::State &previous_state) override;
 
     hardware_interface::CallbackReturn on_deactivate(
-      const rclcpp_lifecycle::State & previous_state) override;
+        const rclcpp_lifecycle::State &previous_state) override;
 
     hardware_interface::CallbackReturn on_shutdown(
-    const rclcpp_lifecycle::State & previous_state) override;
+        const rclcpp_lifecycle::State &previous_state) override;
 
     hardware_interface::return_type read(
-      const rclcpp::Time & time, const rclcpp::Duration & period) override;
+        const rclcpp::Time &time, const rclcpp::Duration &period) override;
 
     hardware_interface::return_type write(
-      const rclcpp::Time & time, const rclcpp::Duration & period) override;
+        const rclcpp::Time &time, const rclcpp::Duration &period) override;
 
-private:
+  private:
     rclcpp::Logger getLogger() { return rclcpp::get_logger("BeckhoffADSHardwareInterface"); }
     std::shared_ptr<rclcpp::Clock> logging_throttle_clock_;
-
-    std::vector<double> hw_commands_;
-    std::vector<double> hw_states_;
 
     // ========= PLC ==============================
 
     // PLC Type and Size Helpers
-    PLCType strToPlcType(const std::string& type_str);
+    PLCType strToPlcType(const std::string &type_str);
     size_t plcTypeByteSize(PLCType type_enum);
 
     // ADS Communication objects
@@ -112,6 +123,8 @@ private:
     // Describes each variable on the PLC
     std::vector<ADSDataLayout> ads_item_layouts_read_;
     std::vector<ADSDataLayout> ads_item_layouts_write_;
+    void configure_ads_read();
+    void configure_ads_write();
     bool build_sum_read_buffers();
     bool build_sum_write_buffers();
 
@@ -129,6 +142,6 @@ private:
     size_t num_items_write_ = 0;
   };
 
-}  // namespace beckhoff_ads_hardware_interface
+} // namespace beckhoff_ads_hardware_interface
 
-#endif  // beckhoff_ads_hardware_interface__BECKHOFF_SYSTEM_HPP_
+#endif // beckhoff_ads_hardware_interface__BECKHOFF_SYSTEM_HPP_

--- a/beckhoff_ads_hardware_interface/include/beckhoff_ads_hardware_interface/beckhoff_ads_hardware_interface.hpp
+++ b/beckhoff_ads_hardware_interface/include/beckhoff_ads_hardware_interface/beckhoff_ads_hardware_interface.hpp
@@ -78,6 +78,22 @@ namespace beckhoff_ads_hardware_interface
     uint32_t NumBytesData; // total num of bytes in this data section
   } ADS_ITEM_REQ_HEADER;
 
+  struct ReadInstruction
+  {
+    size_t read_error_code_offset;
+    size_t buffer_offset;
+    PLCType plc_type;
+    std::string interface_name;
+  };
+
+  struct WriteInstruction
+  {
+    size_t buffer_offset;
+    PLCType plc_type;
+    std::string interface_name;
+    std::string fallback_name; // The state interface name corresponding to the current command interface name
+  };
+
   class BeckhoffADSHardwareInterface : public hardware_interface::SystemInterface
   {
   public:
@@ -85,10 +101,6 @@ namespace beckhoff_ads_hardware_interface
 
     hardware_interface::CallbackReturn on_configure(
         const rclcpp_lifecycle::State &previous_state) override;
-
-    // std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
-
-    // std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
 
     hardware_interface::CallbackReturn on_activate(
         const rclcpp_lifecycle::State &previous_state) override;
@@ -123,8 +135,8 @@ namespace beckhoff_ads_hardware_interface
     // Describes each variable on the PLC
     std::vector<ADSDataLayout> ads_item_layouts_read_;
     std::vector<ADSDataLayout> ads_item_layouts_write_;
-    void configure_ads_read();
-    void configure_ads_write();
+    void ads_read_layout_configure();
+    void ads_write_layout_configure();
     bool build_sum_read_buffers();
     bool build_sum_write_buffers();
 
@@ -140,6 +152,9 @@ namespace beckhoff_ads_hardware_interface
     std::vector<uint8_t> ads_buffer_sum_write_request_;
     std::vector<uint8_t> ads_buffer_sum_write_response_;
     size_t num_items_write_ = 0;
+
+    std::vector<ReadInstruction> ads_read_instructions_;
+    std::vector<WriteInstruction> ads_write_instructions_;
   };
 
 } // namespace beckhoff_ads_hardware_interface

--- a/beckhoff_ads_hardware_interface/package.xml
+++ b/beckhoff_ads_hardware_interface/package.xml
@@ -6,6 +6,7 @@
   <description>Ros2Control hardware interface for integrating with Beckhoff PLC</description>
   <author email="nikola.banovic@b-robotized.com">Nikola Banovic </author>
   <maintainer email="nikola.banovic@b-robotized.com">Nikola Banovic</maintainer>
+  <maintainer email="bartakh.hajar@gmail.com">Hajar Bartakh</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/beckhoff_ads_hardware_interface/src/beckhoff_ads_hardware_interface.cpp
+++ b/beckhoff_ads_hardware_interface/src/beckhoff_ads_hardware_interface.cpp
@@ -38,8 +38,8 @@ namespace beckhoff_ads_hardware_interface
         }
 
         // Fill the ADSDataLayout vectors for read and write operations
-        configure_ads_read();
-        configure_ads_write();
+        ads_read_layout_configure();
+        ads_write_layout_configure();
 
         // Request handles for all symbolic PLC variable names
         RCLCPP_INFO(getLogger(), "Fetching ADS handles for configured PLC variables...");
@@ -135,6 +135,20 @@ namespace beckhoff_ads_hardware_interface
             const uint8_t *ptr = reinterpret_cast<const uint8_t *>(&header);
             ads_buffer_sum_read_request_.insert(ads_buffer_sum_read_request_.end(), ptr, ptr + sizeof(ADS_ITEM_REQ_HEADER));
 
+            // For interfaces targeting the same PLC symbol
+            for (const auto &[index, interface_name] : layout.ros2_interfaces_)
+            {
+                // Fill the read instruction vector
+                ReadInstruction read_instruction;
+                read_instruction.read_error_code_offset = layout.offset_in_read_response_error;
+                read_instruction.buffer_offset = layout.offset_in_read_response_data + index * layout.plc_element_byte_size;
+                read_instruction.plc_type = layout.plc_type;
+                read_instruction.interface_name = interface_name;
+
+                // The state interfaces' names are ordered by ascending indexes of the PLC array thanks to layout.ros2_interfaces_ being a map
+                ads_read_instructions_.push_back(read_instruction);
+            }
+
             current_data_offset += header.NumBytesData;
             current_error_offset += sizeof(uint32_t);
         }
@@ -174,6 +188,27 @@ namespace beckhoff_ads_hardware_interface
             header_block_ptr[i].NumBytesData = layout.plc_element_byte_size * layout.num_elements;
 
             layout.offset_in_write_request_data = total_header_size + current_data_offset;
+
+            // For interfaces targeting the same PLC symbol
+            for (const auto &[index, interface_name] : layout.ros2_interfaces_)
+            {
+                // Fill the write instruction vector
+                WriteInstruction write_instruction;
+                write_instruction.buffer_offset = layout.offset_in_write_request_data + index * layout.plc_element_byte_size;
+                write_instruction.plc_type = layout.plc_type;
+                write_instruction.interface_name = interface_name;
+                write_instruction.fallback_name = "";
+
+                // There exists a state interface for the same PLC symbol
+                if (!layout.state_command_interfaces_map_.empty())
+                {
+                    write_instruction.fallback_name = layout.state_command_interfaces_map_.find(interface_name)->second;
+                }
+
+                // The command interfaces' names are ordered by ascending indexes of the PLC array thanks to layout.ros2_interfaces_ being a map
+                ads_write_instructions_.push_back(write_instruction);
+            }
+
             current_data_offset += header_block_ptr[i].NumBytesData;
             i++;
         }
@@ -183,7 +218,7 @@ namespace beckhoff_ads_hardware_interface
         return true;
     }
 
-    void BeckhoffADSHardwareInterface::configure_ads_read()
+    void BeckhoffADSHardwareInterface::ads_read_layout_configure()
     {
         // Count all state interfaces to pre-allocate memory once and avoid reallocations.
         size_t num_state_interfaces = gpio_state_interfaces_.size() + joint_state_interfaces_.size() + sensor_state_interfaces_.size();
@@ -263,7 +298,7 @@ namespace beckhoff_ads_hardware_interface
         init_ads_read_layout(sensor_state_interfaces_);
     }
 
-    void BeckhoffADSHardwareInterface::configure_ads_write()
+    void BeckhoffADSHardwareInterface::ads_write_layout_configure()
     {
         // Count all command interfaces to pre-allocate memory once and avoid reallocations.
         size_t num_command_interfaces = joint_command_interfaces_.size() + gpio_command_interfaces_.size();
@@ -408,109 +443,107 @@ namespace beckhoff_ads_hardware_interface
         }
 
         bool any_item_read_failed = false;
-        for (const auto &item_layout : ads_item_layouts_read_)
+        for (const auto &read_instruction : ads_read_instructions_)
         {
             uint32_t item_error_code;
             memcpy(&item_error_code,
-                   ads_buffer_sum_read_response_.data() + item_layout.offset_in_read_response_error,
+                   ads_buffer_sum_read_response_.data() + read_instruction.read_error_code_offset,
                    sizeof(uint32_t));
 
             if (item_error_code != ADSERR_NOERR)
             {
                 RCLCPP_WARN_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
-                                     "ADS Sum Read sub-op for '%s' (handle 0x%X) failed: 0x%X.",
-                                     item_layout.plc_name_symbolic.c_str(), item_layout.ads_handle, item_error_code);
+                                     "ADS Sum Read operation corresponding to the state interface '%s' failed: 0x%X.",
+                                     read_instruction.interface_name.c_str(), item_error_code);
+
                 // TODO: See if we need to do something on read error. Maybe assign NaN to the interface?
                 any_item_read_failed = true;
                 continue;
             }
 
-            const uint8_t *ptr_plc_source_data = ads_buffer_sum_read_response_.data() + item_layout.offset_in_read_response_data;
+            // Each state interface has its corresponding read_instruction
+            const uint8_t *ptr_plc_element_current = ads_buffer_sum_read_response_.data() + read_instruction.buffer_offset;
 
             // TODO: performance - Hoist the switch/case above for loop?
-            for (size_t k = 0; k < item_layout.num_elements; ++k)
-            {
-                const uint8_t *ptr_plc_element_current = ptr_plc_source_data + k * item_layout.plc_element_byte_size;
 
-                switch (item_layout.plc_type)
-                {
-                case PLCType::LREAL:
-                {
-                    double val;
-                    memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    set_state(item_layout.ros2_interfaces_.find(k)->second, val);
-                    break;
-                }
-                case PLCType::REAL:
-                {
-                    float val;
-                    memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    set_state(item_layout.ros2_interfaces_.find(k)->second, static_cast<double>(val));
-                    break;
-                }
-                case PLCType::BOOL:
-                {
-                    uint8_t byte_val;
-                    memcpy(&byte_val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    set_state(item_layout.ros2_interfaces_.find(k)->second, (byte_val != 0) ? 1.0 : 0.0);
-                    break;
-                }
-                case PLCType::SINT:
-                {
-                    int8_t val;
-                    memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    set_state(item_layout.ros2_interfaces_.find(k)->second, static_cast<double>(val));
-                    break;
-                }
-                case PLCType::USINT:
-                case PLCType::BYTE:
-                {
-                    uint8_t val;
-                    memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    set_state(item_layout.ros2_interfaces_.find(k)->second, static_cast<double>(val));
-                    break;
-                }
-                case PLCType::INT:
-                {
-                    int16_t val;
-                    memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    set_state(item_layout.ros2_interfaces_.find(k)->second, static_cast<double>(val));
-                    break;
-                }
-                case PLCType::UINT:
-                {
-                    uint16_t val;
-                    memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    set_state(item_layout.ros2_interfaces_.find(k)->second, static_cast<double>(val));
-                    break;
-                }
-                case PLCType::DINT:
-                {
-                    int32_t val;
-                    memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    set_state(item_layout.ros2_interfaces_.find(k)->second, static_cast<double>(val));
-                    break;
-                }
-                case PLCType::UDINT:
-                {
-                    uint32_t val;
-                    memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    set_state(item_layout.ros2_interfaces_.find(k)->second, static_cast<double>(val));
-                    break;
-                }
-                /* Not supported for now, guarded against in on_configure()
-                case PLCType::STRING:
-                    break;
-                */
-                case PLCType::UNKNOWN:
-                default:
-                    RCLCPP_ERROR_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
-                                          "Unhandled or UNKNOWN PLC type (%d) for variable '%s' element %zu during read.",
-                                          static_cast<int>(item_layout.plc_type), item_layout.plc_name_symbolic.c_str(), k);
-                    set_state(item_layout.ros2_interfaces_.find(k)->second, std::numeric_limits<double>::quiet_NaN());
-                    any_item_read_failed = true;
-                    break;
-                }
+            switch (read_instruction.plc_type)
+            {
+            case PLCType::LREAL:
+            {
+                double val;
+                memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
+                set_state(read_instruction.interface_name, val);
+                break;
+            }
+            case PLCType::REAL:
+            {
+                float val;
+                memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
+                set_state(read_instruction.interface_name, static_cast<double>(val));
+                break;
+            }
+            case PLCType::BOOL:
+            {
+                uint8_t byte_val;
+                memcpy(&byte_val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
+                set_state(read_instruction.interface_name, (byte_val != 0) ? 1.0 : 0.0);
+                break;
+            }
+            case PLCType::SINT:
+            {
+                int8_t val;
+                memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
+                set_state(read_instruction.interface_name, static_cast<double>(val));
+                break;
+            }
+            case PLCType::USINT:
+            case PLCType::BYTE:
+            {
+                uint8_t val;
+                memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
+                set_state(read_instruction.interface_name, static_cast<double>(val));
+                break;
+            }
+            case PLCType::INT:
+            {
+                int16_t val;
+                memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
+                set_state(read_instruction.interface_name, static_cast<double>(val));
+                break;
+            }
+            case PLCType::UINT:
+            {
+                uint16_t val;
+                memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
+                set_state(read_instruction.interface_name, static_cast<double>(val));
+                break;
+            }
+            case PLCType::DINT:
+            {
+                int32_t val;
+                memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
+                set_state(read_instruction.interface_name, static_cast<double>(val));
+                break;
+            }
+            case PLCType::UDINT:
+            {
+                uint32_t val;
+                memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
+                set_state(read_instruction.interface_name, static_cast<double>(val));
+                break;
+            }
+            /* Not supported for now, guarded against in on_configure()
+            case PLCType::STRING:
+                break;
+            */
+            case PLCType::UNKNOWN:
+            default:
+                RCLCPP_ERROR_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
+                                      "Unhandled or UNKNOWN PLC type (%d) for the interface '%s' during read.",
+                                      static_cast<int>(read_instruction.plc_type), read_instruction.interface_name.c_str());
+                set_state(read_instruction.interface_name, std::numeric_limits<double>::quiet_NaN());
+                any_item_read_failed = true;
+                break;
             }
         }
         return any_item_read_failed ? hardware_interface::return_type::ERROR : hardware_interface::return_type::OK;
@@ -524,104 +557,99 @@ namespace beckhoff_ads_hardware_interface
             return hardware_interface::return_type::OK;
         }
 
-        for (const auto &item_layout : ads_item_layouts_write_)
+        for (const auto &write_instruction : ads_write_instructions_)
         {
-            uint8_t *ptr_write_buffer_destination = ads_buffer_sum_write_request_.data() + item_layout.offset_in_write_request_data;
+            uint8_t *ptr_write_buffer_destination_current = ads_buffer_sum_write_request_.data() + write_instruction.buffer_offset;
 
             // TODO: performance - Hoist the switch/case above for loop?
-            for (size_t k = 0; k < item_layout.num_elements; ++k)
-            {
-                // store the current val and reset the ros-side command value
-                double val = get_command(item_layout.ros2_interfaces_.find(k)->second);
-                set_command(item_layout.ros2_interfaces_.find(k)->second, std::numeric_limits<double>::quiet_NaN());
 
+            // store the current val and reset the ros-side command value
+            double val = get_command(write_instruction.interface_name);
+            set_command(write_instruction.interface_name, std::numeric_limits<double>::quiet_NaN());
+
+            if (std::isnan(val))
+            {
+                // if the original value was NaN and there exist a state interface of the same name, write corresponding state interface
+                if (!write_instruction.fallback_name.empty())
+                {
+                    val = get_state(write_instruction.fallback_name);
+                }
+
+                // if we STILL don't have a fallback value on, don't update the write buffer.
+                // the last valid command is written
                 if (std::isnan(val))
                 {
-                    // if the original value was NaN and there exist a state interface of the same name, write corresponding state interface
-                    if (!item_layout.state_command_interfaces_map_.empty())
-                    {
-                        std::string current_command_interface_name = item_layout.ros2_interfaces_.find(k)->second;
-                        val = get_state(item_layout.state_command_interfaces_map_.find(current_command_interface_name)->second);
-                    }
+                    continue;
+                }
+            }
 
-                    // if we STILL don't have a fallback value on, don't update the write buffer.
-                    // the last valid command is written
-                    if (std::isnan(val))
-                    {
-                        continue;
-                    }
-                }
-
-                uint8_t *ptr_write_buffer_destination_current = ptr_write_buffer_destination + (k * item_layout.plc_element_byte_size);
-
-                switch (item_layout.plc_type)
-                {
-                case PLCType::LREAL:
-                {
-                    // val is already double (LREAL is 8 bytes - 64 bit)
-                    memcpy(ptr_write_buffer_destination_current, &val, item_layout.plc_element_byte_size);
-                    break;
-                }
-                case PLCType::REAL:
-                {
-                    float plc_val = static_cast<float>(val);
-                    memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
-                    break;
-                }
-                case PLCType::BOOL:
-                {
-                    // bool is size of byte in PLC
-                    uint8_t plc_val = (val != 0.0) ? 1 : 0;
-                    memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
-                    break;
-                }
-                case PLCType::SINT:
-                {
-                    int8_t plc_val = static_cast<int8_t>(std::round(val));
-                    memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
-                    break;
-                }
-                case PLCType::USINT:
-                case PLCType::BYTE:
-                {
-                    uint8_t plc_val = static_cast<uint8_t>(std::round(val));
-                    memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
-                    break;
-                }
-                case PLCType::INT:
-                {
-                    int16_t plc_val = static_cast<int16_t>(std::round(val));
-                    memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
-                    break;
-                }
-                case PLCType::UINT:
-                {
-                    uint16_t plc_val = static_cast<uint16_t>(std::round(val));
-                    memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
-                    break;
-                }
-                case PLCType::DINT:
-                {
-                    int32_t plc_val = static_cast<int32_t>(std::round(val));
-                    memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
-                    break;
-                }
-                case PLCType::UDINT:
-                {
-                    uint32_t plc_val = static_cast<uint32_t>(std::round(val));
-                    memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
-                    break;
-                }
-                /* String not supported for now
-                case PLCType::STRING: break;
-                */
-                case PLCType::UNKNOWN:
-                default:
-                    RCLCPP_FATAL(getLogger(), "UNKNOWN PLC type (%d) for variable '%s' element %zu during write. Sending zeroed data of size %zu.",
-                                 static_cast<int>(item_layout.plc_type), item_layout.plc_name_symbolic.c_str(), k, item_layout.plc_element_byte_size);
-                    return hardware_interface::return_type::ERROR;
-                    break;
-                }
+            switch (write_instruction.plc_type)
+            {
+            case PLCType::LREAL:
+            {
+                // val is already double (LREAL is 8 bytes - 64 bit)
+                memcpy(ptr_write_buffer_destination_current, &val, plcTypeByteSize(write_instruction.plc_type));
+                break;
+            }
+            case PLCType::REAL:
+            {
+                float plc_val = static_cast<float>(val);
+                memcpy(ptr_write_buffer_destination_current, &plc_val, plcTypeByteSize(write_instruction.plc_type));
+                break;
+            }
+            case PLCType::BOOL:
+            {
+                // bool is size of byte in PLC
+                uint8_t plc_val = (val != 0.0) ? 1 : 0;
+                memcpy(ptr_write_buffer_destination_current, &plc_val, plcTypeByteSize(write_instruction.plc_type));
+                break;
+            }
+            case PLCType::SINT:
+            {
+                int8_t plc_val = static_cast<int8_t>(std::round(val));
+                memcpy(ptr_write_buffer_destination_current, &plc_val, plcTypeByteSize(write_instruction.plc_type));
+                break;
+            }
+            case PLCType::USINT:
+            case PLCType::BYTE:
+            {
+                uint8_t plc_val = static_cast<uint8_t>(std::round(val));
+                memcpy(ptr_write_buffer_destination_current, &plc_val, plcTypeByteSize(write_instruction.plc_type));
+                break;
+            }
+            case PLCType::INT:
+            {
+                int16_t plc_val = static_cast<int16_t>(std::round(val));
+                memcpy(ptr_write_buffer_destination_current, &plc_val, plcTypeByteSize(write_instruction.plc_type));
+                break;
+            }
+            case PLCType::UINT:
+            {
+                uint16_t plc_val = static_cast<uint16_t>(std::round(val));
+                memcpy(ptr_write_buffer_destination_current, &plc_val, plcTypeByteSize(write_instruction.plc_type));
+                break;
+            }
+            case PLCType::DINT:
+            {
+                int32_t plc_val = static_cast<int32_t>(std::round(val));
+                memcpy(ptr_write_buffer_destination_current, &plc_val, plcTypeByteSize(write_instruction.plc_type));
+                break;
+            }
+            case PLCType::UDINT:
+            {
+                uint32_t plc_val = static_cast<uint32_t>(std::round(val));
+                memcpy(ptr_write_buffer_destination_current, &plc_val, plcTypeByteSize(write_instruction.plc_type));
+                break;
+            }
+            /* String not supported for now
+            case PLCType::STRING: break;
+            */
+            case PLCType::UNKNOWN:
+            default:
+                RCLCPP_FATAL(getLogger(), "UNKNOWN PLC type (%d) for the interface '%s' during write. Sending zeroed data of size %zu.",
+                             static_cast<int>(write_instruction.plc_type), write_instruction.interface_name.c_str(), plcTypeByteSize(write_instruction.plc_type));
+                return hardware_interface::return_type::ERROR;
+                break;
             }
         }
 

--- a/beckhoff_ads_hardware_interface/src/beckhoff_ads_hardware_interface.cpp
+++ b/beckhoff_ads_hardware_interface/src/beckhoff_ads_hardware_interface.cpp
@@ -19,456 +19,483 @@
 
 namespace beckhoff_ads_hardware_interface
 {
-hardware_interface::CallbackReturn BeckhoffADSHardwareInterface::on_init(
-  const hardware_interface::HardwareComponentParams & /*params*/)
-{
-  logging_throttle_clock_ = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+    hardware_interface::CallbackReturn BeckhoffADSHardwareInterface::on_init(
+        const hardware_interface::HardwareComponentParams & /*params*/)
+    {
+        logging_throttle_clock_ = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
 
-  return CallbackReturn::SUCCESS;
-}
-
-hardware_interface::CallbackReturn BeckhoffADSHardwareInterface::on_configure(
-  const rclcpp_lifecycle::State & /*previous_state*/)
-{
-    // Configure ADS Client Device
-    if ( !configure_ads_device() ) {
-        RCLCPP_FATAL(getLogger(), "Failed to configure ADS device from URDF parameters.");
-        return hardware_interface::CallbackReturn::ERROR;
+        return CallbackReturn::SUCCESS;
     }
 
-    // Request handles for all symbolic PLC variable names
-    RCLCPP_INFO(getLogger(), "Fetching ADS handles for configured PLC variables...");
-    for(auto& layout : ads_item_layouts_read_) {
-        try {
-            layout.ads_handle = *(ads_device_->GetHandle(layout.plc_name_symbolic));
-        } catch (const std::exception& ex) {
-            RCLCPP_ERROR(getLogger(), "\tADS Exception getting handle for '%s': %s. Read operations for this variable will fail.", layout.plc_name_symbolic.c_str(), ex.what());
+    hardware_interface::CallbackReturn BeckhoffADSHardwareInterface::on_configure(
+        const rclcpp_lifecycle::State & /*previous_state*/)
+    {
+        // Configure ADS Client Device
+        if (!configure_ads_device())
+        {
+            RCLCPP_FATAL(getLogger(), "Failed to configure ADS device from URDF parameters.");
+            return hardware_interface::CallbackReturn::ERROR;
         }
-    }
-    for(auto& layout : ads_item_layouts_write_) {
-        try {
-            layout.ads_handle = *(ads_device_->GetHandle(layout.plc_name_symbolic));
-        } catch (const std::exception& ex) {
-            RCLCPP_ERROR(getLogger(), "\tADS Exception getting handle for '%s': %s. Write operations for this variable will fail.", layout.plc_name_symbolic.c_str(), ex.what());
-        }
-    }
-    RCLCPP_INFO(getLogger(), "\tHandles acquired");
 
-    // Pre-pack what we can for SUM read/write commands
-    if ( !build_sum_read_buffers() ) {
-        RCLCPP_FATAL(getLogger(), "\tFailed to build ADS sum read buffer.");
-        return hardware_interface::CallbackReturn::ERROR;
-    }
-    if ( !build_sum_write_buffers() ) {
-        RCLCPP_FATAL(getLogger(), "\tFailed to build ADS sum write buffer.");
-        return hardware_interface::CallbackReturn::ERROR;
-    }
+        // Fill the ADSDataLayout vectors for read and write operations
+        configure_ads_read();
+        configure_ads_write();
 
-    // Link command interfaces to their corresponding state interfaces
-    RCLCPP_INFO(getLogger(), "Linking command interfaces to state interfaces...");
-    for (auto& command_layout : ads_item_layouts_write_) {
-        for (const auto& state_layout : ads_item_layouts_read_) {
-            if (command_layout.plc_name_symbolic == state_layout.plc_name_symbolic) {
-                command_layout.offset_in_ros2_control_state_ = state_layout.offset_in_ros2_control;
-                RCLCPP_INFO(getLogger(), "\tLinked command '%s' to state at hw_states_[%zu]",
-                            command_layout.plc_name_symbolic.c_str(),
-                            command_layout.offset_in_ros2_control_state_);
-                break;
+        // Request handles for all symbolic PLC variable names
+        RCLCPP_INFO(getLogger(), "Fetching ADS handles for configured PLC variables...");
+        for (auto &layout : ads_item_layouts_read_)
+        {
+            try
+            {
+                layout.ads_handle = *(ads_device_->GetHandle(layout.plc_name_symbolic));
+            }
+            catch (const std::exception &ex)
+            {
+                RCLCPP_ERROR(getLogger(), "\tADS Exception getting handle for '%s': %s. Read operations for this variable will fail.", layout.plc_name_symbolic.c_str(), ex.what());
             }
         }
+        for (auto &layout : ads_item_layouts_write_)
+        {
+            try
+            {
+                layout.ads_handle = *(ads_device_->GetHandle(layout.plc_name_symbolic));
+            }
+            catch (const std::exception &ex)
+            {
+                RCLCPP_ERROR(getLogger(), "\tADS Exception getting handle for '%s': %s. Write operations for this variable will fail.", layout.plc_name_symbolic.c_str(), ex.what());
+            }
+        }
+        RCLCPP_INFO(getLogger(), "\tHandles acquired");
+
+        // Pre-pack what we can for SUM read/write commands
+        if (!build_sum_read_buffers())
+        {
+            RCLCPP_FATAL(getLogger(), "\tFailed to build ADS sum read buffer.");
+            return hardware_interface::CallbackReturn::ERROR;
+        }
+        if (!build_sum_write_buffers())
+        {
+            RCLCPP_FATAL(getLogger(), "\tFailed to build ADS sum write buffer.");
+            return hardware_interface::CallbackReturn::ERROR;
+        }
+
+        // Link command interfaces to their corresponding state interfaces
+        RCLCPP_INFO(getLogger(), "Linking command interfaces to state interfaces...");
+        for (auto &command_layout : ads_item_layouts_write_)
+        {
+            for (const auto &state_layout : ads_item_layouts_read_)
+            {
+                if (command_layout.plc_name_symbolic == state_layout.plc_name_symbolic)
+                {
+                    for (size_t k = 0; k < command_layout.num_elements; ++k)
+                    {
+                        // The pair is made of (command_interface_name, corresponding_state_interface_name)
+                        auto pair = std::make_pair(command_layout.ros2_interfaces_.find(k)->second, state_layout.ros2_interfaces_.find(k)->second);
+                        command_layout.state_command_interfaces_map_.emplace(pair);
+                    }
+                }
+            }
+        }
+
+        return CallbackReturn::SUCCESS;
     }
 
-    return CallbackReturn::SUCCESS;
-}
+    bool BeckhoffADSHardwareInterface::build_sum_read_buffers()
+    {
+        num_items_read_ = ads_item_layouts_read_.size();
+        if (num_items_read_ == 0)
+        {
+            RCLCPP_INFO(getLogger(), "No items to configure for ADS Sum READ.");
+            return true;
+        }
+        RCLCPP_INFO(getLogger(), "Building ADS sum READ buffer...");
 
-bool BeckhoffADSHardwareInterface::build_sum_read_buffers() {
-    num_items_read_ = ads_item_layouts_read_.size();
-    if (num_items_read_ == 0) {
-        RCLCPP_INFO(getLogger(), "No items to configure for ADS Sum READ.");
+        size_t total_error_block_size = num_items_read_ * sizeof(uint32_t);
+        size_t total_data_block_size = 0;
+        for (const auto &layout : ads_item_layouts_read_)
+        {
+            total_data_block_size += layout.plc_element_byte_size * layout.num_elements;
+        }
+
+        ads_buffer_sum_read_response_.resize(total_error_block_size + total_data_block_size);
+        ads_buffer_sum_read_request_.clear();
+
+        size_t current_data_offset = 0;
+        size_t current_error_offset = 0;
+
+        for (auto &layout : ads_item_layouts_read_)
+        {
+            layout.offset_in_read_response_data = total_error_block_size + current_data_offset;
+            layout.offset_in_read_response_error = current_error_offset;
+
+            ADS_ITEM_REQ_HEADER header;
+            header.indexGroup = ADSIGRP_SYM_VALBYHND;
+            header.indexOffset = layout.ads_handle;
+            header.NumBytesData = layout.plc_element_byte_size * layout.num_elements;
+            const uint8_t *ptr = reinterpret_cast<const uint8_t *>(&header);
+            ads_buffer_sum_read_request_.insert(ads_buffer_sum_read_request_.end(), ptr, ptr + sizeof(ADS_ITEM_REQ_HEADER));
+
+            current_data_offset += header.NumBytesData;
+            current_error_offset += sizeof(uint32_t);
+        }
+        RCLCPP_INFO(getLogger(), "ADS Sum READ configured for %zu items. Request: %zu bytes, Response: %zu bytes.",
+                    num_items_read_, ads_buffer_sum_read_request_.size(), ads_buffer_sum_read_response_.size());
         return true;
     }
-    RCLCPP_INFO(getLogger(), "Building ADS sum READ buffer...");
 
-    size_t total_error_block_size = num_items_read_ * sizeof(uint32_t);
-    size_t total_data_block_size = 0;
-    for(const auto& layout : ads_item_layouts_read_) {
-        total_data_block_size += layout.plc_element_byte_size * layout.num_elements;
-    }
+    bool BeckhoffADSHardwareInterface::build_sum_write_buffers()
+    {
+        RCLCPP_INFO(getLogger(), "Building ADS sum WRITE buffer...");
+        num_items_write_ = ads_item_layouts_write_.size();
+        if (num_items_write_ == 0)
+        {
+            RCLCPP_INFO(getLogger(), "No items to configure for ADS Sum WRITE.");
+            return true;
+        }
 
-    ads_buffer_sum_read_response_.resize(total_error_block_size + total_data_block_size);
-    ads_buffer_sum_read_request_.clear();
+        size_t total_data_size = 0;
+        size_t total_header_size = num_items_write_ * sizeof(ADS_ITEM_REQ_HEADER);
+        for (const auto &layout : ads_item_layouts_write_)
+        {
+            total_data_size += layout.plc_element_byte_size * layout.num_elements;
+        }
 
-    size_t current_data_offset = 0;
-    size_t current_error_offset = 0;
+        ads_buffer_sum_write_request_.resize(total_header_size + total_data_size);
+        ads_buffer_sum_write_response_.resize(num_items_write_ * sizeof(uint32_t));
 
-    for(auto& layout : ads_item_layouts_read_) {
-        layout.offset_in_read_response_data = total_error_block_size + current_data_offset;
-        layout.offset_in_read_response_error = current_error_offset;
+        auto *header_block_ptr = reinterpret_cast<ADS_ITEM_REQ_HEADER *>(ads_buffer_sum_write_request_.data());
+        size_t current_data_offset = 0;
+        size_t i = 0; // Index for the header block pointer
 
-        ADS_ITEM_REQ_HEADER header;
-        header.indexGroup = ADSIGRP_SYM_VALBYHND;
-        header.indexOffset = layout.ads_handle;
-        header.NumBytesData = layout.plc_element_byte_size * layout.num_elements;
-        const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&header);
-        ads_buffer_sum_read_request_.insert(ads_buffer_sum_read_request_.end(), ptr, ptr + sizeof(ADS_ITEM_REQ_HEADER));
+        for (auto &layout : ads_item_layouts_write_)
+        {
+            header_block_ptr[i].indexGroup = ADSIGRP_SYM_VALBYHND;
+            header_block_ptr[i].indexOffset = layout.ads_handle;
+            header_block_ptr[i].NumBytesData = layout.plc_element_byte_size * layout.num_elements;
 
-        current_data_offset += header.NumBytesData;
-        current_error_offset += sizeof(uint32_t);
-    }
-    RCLCPP_INFO(getLogger(), "ADS Sum READ configured for %zu items. Request: %zu bytes, Response: %zu bytes.",
-                num_items_read_, ads_buffer_sum_read_request_.size(), ads_buffer_sum_read_response_.size());
-    return true;
-}
+            layout.offset_in_write_request_data = total_header_size + current_data_offset;
+            current_data_offset += header_block_ptr[i].NumBytesData;
+            i++;
+        }
 
-bool BeckhoffADSHardwareInterface::build_sum_write_buffers() {
-    RCLCPP_INFO(getLogger(), "Building ADS sum WRITE buffer...");
-    num_items_write_ = ads_item_layouts_write_.size();
-    if (num_items_write_ == 0) {
-        RCLCPP_INFO(getLogger(), "No items to configure for ADS Sum WRITE.");
+        RCLCPP_INFO(getLogger(), "ADS Sum WRITE configured for %zu items. Request: %zu bytes, Response: %zu bytes.",
+                    num_items_write_, ads_buffer_sum_write_request_.size(), ads_buffer_sum_write_response_.size());
         return true;
     }
 
-    size_t total_data_size = 0;
-    size_t total_header_size = num_items_write_ * sizeof(ADS_ITEM_REQ_HEADER);
-    for (const auto& layout : ads_item_layouts_write_) {
-        total_data_size += layout.plc_element_byte_size * layout.num_elements;
-    }
+    void BeckhoffADSHardwareInterface::configure_ads_read()
+    {
+        // Count all state interfaces to pre-allocate memory once and avoid reallocations.
+        size_t num_state_interfaces = gpio_state_interfaces_.size() + joint_state_interfaces_.size() + sensor_state_interfaces_.size();
 
-    ads_buffer_sum_write_request_.resize(total_header_size + total_data_size);
-    ads_buffer_sum_write_response_.resize(num_items_write_ * sizeof(uint32_t));
+        // Reserve worst-case scenario for layouts (each interface targets a different PLC symbol)
+        ads_item_layouts_read_.clear();
+        ads_item_layouts_read_.reserve(num_state_interfaces);
 
-    auto* header_block_ptr = reinterpret_cast<ADS_ITEM_REQ_HEADER*>(ads_buffer_sum_write_request_.data());
-    size_t current_data_offset = 0;
-    size_t i = 0; // Index for the header block pointer
+        // Keep track of multiple interfaces targeting the same PLC symbol of type ARRAY[x], but different index
+        std::map<std::string, bool> processed_plc_symbols;
 
-    for (auto& layout : ads_item_layouts_write_){
-        header_block_ptr[i].indexGroup = ADSIGRP_SYM_VALBYHND;
-        header_block_ptr[i].indexOffset = layout.ads_handle;
-        header_block_ptr[i].NumBytesData = layout.plc_element_byte_size * layout.num_elements;
-
-        layout.offset_in_write_request_data = total_header_size + current_data_offset;
-        current_data_offset += header_block_ptr[i].NumBytesData;
-        i++;
-    }
-
-    RCLCPP_INFO(getLogger(), "ADS Sum WRITE configured for %zu items. Request: %zu bytes, Response: %zu bytes.",
-                num_items_write_, ads_buffer_sum_write_request_.size(), ads_buffer_sum_write_response_.size());
-    return true;
-}
-
-std::vector<hardware_interface::StateInterface> BeckhoffADSHardwareInterface::export_state_interfaces()
-{
-    RCLCPP_INFO(getLogger(), "Exporting state interfaces...");
-
-    // Count all state interfaces to pre-allocate memory once and avoid reallocations.
-    size_t num_state_interfaces = 0;
-    for (const auto& joint : info_.joints) { num_state_interfaces += joint.state_interfaces.size(); }
-    for (const auto& gpio : info_.gpios) { num_state_interfaces += gpio.state_interfaces.size(); }
-    for (const auto& sensor : info_.sensors) { num_state_interfaces += sensor.state_interfaces.size(); }
-
-    std::vector<hardware_interface::StateInterface> state_interfaces;
-    state_interfaces.reserve(num_state_interfaces);
-    hw_states_.resize(num_state_interfaces, std::numeric_limits<double>::quiet_NaN());
-    // Reserve worst-case scenario for layouts (each interface targets a different PLC symbol)
-    ads_item_layouts_read_.clear();
-    ads_item_layouts_read_.reserve(num_state_interfaces);
-
-
-    // Keep track of multiple interfaces targeting the same PLC symbol of type ARRAY[x], but different index
-    std::map<std::string, bool> processed_plc_symbols;
-    size_t current_hw_states_idx = 0;
-
-    auto export_hardware_component_states =
-        [&](const auto& components, const std::string& component_type_str) {
-        for (const auto& component_info : components) {
-            for (const auto& interface_info : component_info.state_interfaces) {
-
-                state_interfaces.emplace_back(hardware_interface::StateInterface(
-                    component_info.name, interface_info.name, &hw_states_[current_hw_states_idx]));
-
+        auto init_ads_read_layout =
+            [&](const auto &type_state_interfaces_)
+        {
+            for (const auto &[name, descr] : type_state_interfaces_)
+            {
                 std::string plc_symbol;
                 std::string plc_type_str;
                 size_t num_elements = 1;
                 size_t plc_index = 0;
-                try {
-                    plc_symbol = interface_info.parameters.at("PLC_symbol");
-                    plc_type_str = interface_info.parameters.at("PLC_type");
-                    if (interface_info.parameters.count("n_elements")) {
-                        num_elements = std::stoul(interface_info.parameters.at("n_elements"));
+                try
+                {
+                    plc_symbol = descr.interface_info.parameters.at("PLC_symbol");
+                    plc_type_str = descr.interface_info.parameters.at("PLC_type");
+                    if (descr.interface_info.parameters.count("n_elements"))
+                    {
+                        num_elements = std::stoul(descr.interface_info.parameters.at("n_elements"));
                     }
-                    if (interface_info.parameters.count("index")) {
-                        plc_index = std::stoul(interface_info.parameters.at("index"));
+                    if (descr.interface_info.parameters.count("index"))
+                    {
+                        plc_index = std::stoul(descr.interface_info.parameters.at("index"));
                     }
-                } catch (const std::exception& e) {
-                    RCLCPP_ERROR(getLogger(), "Error parsing PLC parameters for state interface '%s/%s': %s. Check URDF.",
-                                 component_info.name.c_str(), interface_info.name.c_str(), e.what());
-                    current_hw_states_idx++;
+                }
+                catch (const std::exception &e)
+                {
+                    RCLCPP_ERROR(getLogger(), "Error parsing PLC parameters for state interface '%s': %s. Check URDF.",
+                                 name.c_str(), e.what());
                     continue;
                 }
 
                 // If this is the first time we see this symbol, create the layout
-                if (processed_plc_symbols.find(plc_symbol) == processed_plc_symbols.end()) {
+                if (processed_plc_symbols.find(plc_symbol) == processed_plc_symbols.end())
+                {
                     ADSDataLayout layout;
                     layout.plc_name_symbolic = plc_symbol;
                     layout.num_elements = num_elements;
                     layout.plc_type = strToPlcType(plc_type_str);
+                    layout.ros2_interfaces_.emplace(std::make_pair(plc_index, name));
 
-                    if (layout.plc_type == PLCType::UNKNOWN || layout.plc_type == PLCType::STRING) {
+                    if (layout.plc_type == PLCType::UNKNOWN || layout.plc_type == PLCType::STRING)
+                    {
                         RCLCPP_ERROR(getLogger(), "Skipping state variable '%s' due to UNSUPPORTED or UNKNOWN PLC_type '%s'.", layout.plc_name_symbolic.c_str(), plc_type_str.c_str());
-                    } else {
+                    }
+                    else
+                    {
                         layout.plc_element_byte_size = plcTypeByteSize(layout.plc_type);
-                        layout.offset_in_ros2_control = current_hw_states_idx;
                         ads_item_layouts_read_.push_back(layout);
                         processed_plc_symbols[plc_symbol] = true;
                     }
                 }
+                // The symbol already exists
+                else
+                {
+                    // Find the ADS Data Layout object of the corresponding PLC symbol
+                    auto it = std::find_if(ads_item_layouts_read_.begin(), ads_item_layouts_read_.end(),
+                                           [&plc_symbol](ADSDataLayout layout)
+                                           { return layout.plc_name_symbolic == plc_symbol; });
 
-                // Log success
-                if (num_elements > 1) {
-                    plc_symbol += "[" + std::to_string(plc_index) + "]";
+                    // Add the interface name the layout
+                    (*it).ros2_interfaces_.emplace(std::make_pair(plc_index, name));
                 }
-                RCLCPP_INFO(getLogger(), "\t%s '%s/%s' | hw_states_[%zu] <-- %s",
-                    component_type_str.c_str(), component_info.name.c_str(), interface_info.name.c_str(), current_hw_states_idx, plc_symbol.c_str());
-
-                current_hw_states_idx++;
             }
-        }
-    };
+        };
 
+        init_ads_read_layout(joint_state_interfaces_);
+        init_ads_read_layout(gpio_state_interfaces_);
+        init_ads_read_layout(sensor_state_interfaces_);
+    }
 
-    export_hardware_component_states(info_.joints, "joint");
-    export_hardware_component_states(info_.gpios, "gpio");
-    export_hardware_component_states(info_.sensors, "sensor");
+    void BeckhoffADSHardwareInterface::configure_ads_write()
+    {
+        // Count all command interfaces to pre-allocate memory once and avoid reallocations.
+        size_t num_command_interfaces = joint_command_interfaces_.size() + gpio_command_interfaces_.size();
 
-    return state_interfaces;
-}
+        // Reserve worst-case scenario for layouts (each interface targets a different PLC symbol)
+        ads_item_layouts_write_.clear();
+        ads_item_layouts_write_.reserve(num_command_interfaces);
 
-std::vector<hardware_interface::CommandInterface> BeckhoffADSHardwareInterface::export_command_interfaces()
-{
-    RCLCPP_INFO(getLogger(), "Exporting command interfaces...");
+        // Keep track of multiple interfaces targeting the same PLC symbol of type ARRAY[x], but different index
+        std::map<std::string, bool> processed_plc_symbols;
 
-    // Count all command interfaces to pre-allocate memory once and avoid reallocations.
-    size_t num_command_interfaces = 0;
-    for (const auto& joint : info_.joints) { num_command_interfaces += joint.command_interfaces.size(); }
-    for (const auto& gpio : info_.gpios) { num_command_interfaces += gpio.command_interfaces.size(); }
+        auto init_ads_write_layout =
+            [&](const auto &type_command_interfaces_)
+        {
+            for (const auto &[name, descr] : type_command_interfaces_)
+            {
+                [[maybe_unused]] double initial_value = std::numeric_limits<double>::quiet_NaN();
 
-    std::vector<hardware_interface::CommandInterface> command_interfaces;
-    command_interfaces.reserve(num_command_interfaces);
-    hw_commands_.resize(num_command_interfaces, std::numeric_limits<double>::quiet_NaN());
-
-    // Reserve worst-case scenario for layouts (each interface targets a different PLC symbol)
-    ads_item_layouts_write_.clear();
-    ads_item_layouts_write_.reserve(num_command_interfaces);
-
-
-    // Keep track of multiple interfaces targeting the same PLC symbol of type ARRAY[x], but different index
-    std::map<std::string, bool> processed_plc_symbols;
-    size_t current_hw_commands_idx = 0;
-
-    auto export_hardware_component_commands =
-        [&](const auto& components, const std::string& component_type_str) {
-        for (const auto& component_info : components) {
-            for (const auto& interface_info : component_info.command_interfaces) {
-
-                double initial_value = std::numeric_limits<double>::quiet_NaN();
-
-                if (interface_info.parameters.count("initial_value")) {
-                    try { initial_value = std::stod(interface_info.parameters.at("initial_value")); }
-                    catch(const std::exception& ex) { // Catch conversion errors
+                if (descr.interface_info.parameters.count("initial_value"))
+                {
+                    try
+                    {
+                        initial_value = std::stod(descr.interface_info.parameters.at("initial_value"));
+                    }
+                    catch (const std::exception &ex)
+                    { // Catch conversion errors
                         RCLCPP_WARN(
                             getLogger(),
-                            "Invalid 'initial_value' ('%s') for interface '%s' of component '%s'. Using NaN. Error: %s",
-                            interface_info.parameters.at("initial_value").c_str(),
-                            interface_info.name.c_str(),
-                            component_info.name.c_str(),
-                            ex.what()
-                        );
+                            "Invalid 'initial_value' ('%s') for command interface '%s'. Using NaN. Error: %s",
+                            descr.interface_info.parameters.at("initial_value").c_str(),
+                            name.c_str(),
+                            ex.what());
                     }
                 }
-                hw_commands_[ current_hw_commands_idx ] = initial_value;
-
-                command_interfaces.emplace_back(hardware_interface::CommandInterface(
-                component_info.name, interface_info.name, &hw_commands_[ current_hw_commands_idx ]));
 
                 std::string plc_symbol;
                 std::string plc_type_str;
                 size_t num_elements = 1;
                 size_t plc_index = 0;
-                try {
-                    plc_symbol = interface_info.parameters.at("PLC_symbol");
-                    plc_type_str = interface_info.parameters.at("PLC_type");
-                    if (interface_info.parameters.count("n_elements")) {
-                        num_elements = std::stoul(interface_info.parameters.at("n_elements"));
+                try
+                {
+                    plc_symbol = descr.interface_info.parameters.at("PLC_symbol");
+                    plc_type_str = descr.interface_info.parameters.at("PLC_type");
+                    if (descr.interface_info.parameters.count("n_elements"))
+                    {
+                        num_elements = std::stoul(descr.interface_info.parameters.at("n_elements"));
                     }
-                    if (interface_info.parameters.count("index")) {
-                        plc_index = std::stoul(interface_info.parameters.at("index"));
+                    if (descr.interface_info.parameters.count("index"))
+                    {
+                        plc_index = std::stoul(descr.interface_info.parameters.at("index"));
                     }
-                } catch (const std::exception& e) {
-                    RCLCPP_ERROR(getLogger(), "Error parsing PLC parameters for command interface '%s/%s': %s. Check URDF.",
-                                 component_info.name.c_str(), interface_info.name.c_str(), e.what());
-                    current_hw_commands_idx++;
+                }
+                catch (const std::exception &e)
+                {
+                    RCLCPP_ERROR(getLogger(), "Error parsing PLC parameters for command interface '%s': %s. Check URDF.",
+                                 name.c_str(), e.what());
                     continue;
                 }
 
-                if (processed_plc_symbols.find(plc_symbol) == processed_plc_symbols.end()) {
+                if (processed_plc_symbols.find(plc_symbol) == processed_plc_symbols.end())
+                {
                     ADSDataLayout layout;
                     layout.plc_name_symbolic = plc_symbol;
                     layout.num_elements = num_elements;
                     layout.plc_type = strToPlcType(plc_type_str);
+                    layout.ros2_interfaces_.emplace(std::make_pair(plc_index, name));
 
-                    if (layout.plc_type == PLCType::UNKNOWN || layout.plc_type == PLCType::STRING) {
-                         RCLCPP_ERROR(getLogger(), "Skipping command variable '%s' due to UNSUPPORTED or UNKNOWN PLC_type '%s'.", layout.plc_name_symbolic.c_str(), plc_type_str.c_str());
-                    } else {
+                    if (layout.plc_type == PLCType::UNKNOWN || layout.plc_type == PLCType::STRING)
+                    {
+                        RCLCPP_ERROR(getLogger(), "Skipping command variable '%s' due to UNSUPPORTED or UNKNOWN PLC_type '%s'.", layout.plc_name_symbolic.c_str(), plc_type_str.c_str());
+                    }
+                    else
+                    {
                         layout.plc_element_byte_size = plcTypeByteSize(layout.plc_type);
-                        // offset_in_ros2_control points to the START of the block for this variable.
-                        layout.offset_in_ros2_control = current_hw_commands_idx;
                         ads_item_layouts_write_.push_back(layout);
                         processed_plc_symbols[plc_symbol] = true;
                     }
                 }
+                // The symbol already exists
+                else
+                {
+                    // Look for the ADS Data Layout of the corresponding PLC symbol
+                    auto it = std::find_if(ads_item_layouts_write_.begin(), ads_item_layouts_write_.end(),
+                                           [&plc_symbol](ADSDataLayout layout)
+                                           { return layout.plc_name_symbolic == plc_symbol; });
 
-                // Log success
-                if (num_elements > 1) {
-                    plc_symbol += "[" + std::to_string(plc_index) + "]";
+                    // Add the command interface name the layout
+                    (*it).ros2_interfaces_.emplace(std::make_pair(plc_index, name));
                 }
-                RCLCPP_INFO(getLogger(), "\t%s '%s/%s' | hw_commands_[%zu] --> %s",
-                    component_type_str.c_str(), component_info.name.c_str(), interface_info.name.c_str(), current_hw_commands_idx, plc_symbol.c_str());
-
-                current_hw_commands_idx++;
             }
-        }
-    };
+        };
 
-    export_hardware_component_commands(info_.joints, "joint");
-    export_hardware_component_commands(info_.gpios, "gpio");
-
-    return command_interfaces;
-}
-
-hardware_interface::CallbackReturn BeckhoffADSHardwareInterface::on_activate(
-  const rclcpp_lifecycle::State & /*previous_state*/)
-{
-  return CallbackReturn::SUCCESS;
-}
-
-hardware_interface::CallbackReturn BeckhoffADSHardwareInterface::on_deactivate(
-  const rclcpp_lifecycle::State & /*previous_state*/)
-{
-  // TODO: send some safety commands to the PLC?
-  return CallbackReturn::SUCCESS;
-}
-
-hardware_interface::return_type BeckhoffADSHardwareInterface::read(
-  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
-{
-    if (num_items_read_  == 0) {
-        return hardware_interface::return_type::OK;
+        init_ads_write_layout(joint_command_interfaces_);
+        init_ads_write_layout(gpio_command_interfaces_);
     }
 
-
-    uint32_t bytes_read_from_plc = 0;
-    long ads_sum_read_error = ads_device_->ReadWriteReqEx2(
-        ADSIGRP_SUMUP_READ,
-        num_items_read_,
-        ads_buffer_sum_read_response_.size(),
-        ads_buffer_sum_read_response_.data(),
-        ads_buffer_sum_read_request_.size(),
-        ads_buffer_sum_read_request_.data(),
-        &bytes_read_from_plc
-    );
-
-    if (ads_sum_read_error != ADSERR_NOERR) {
-        RCLCPP_ERROR_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
-                              "Overall ADS Sum Read Error: 0x%lX.", ads_sum_read_error);
-        // TODO: See if we need to do something on read error. Maybe assign NaN to all interfaces?
-        return hardware_interface::return_type::ERROR;
+    hardware_interface::CallbackReturn BeckhoffADSHardwareInterface::on_activate(
+        const rclcpp_lifecycle::State & /*previous_state*/)
+    {
+        return CallbackReturn::SUCCESS;
     }
 
-    if (bytes_read_from_plc != ads_buffer_sum_read_response_.size()) {
-        RCLCPP_ERROR_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
-                              "ADS Sum Read size mismatch. Expected %zu, Got %u.",
-                              ads_buffer_sum_read_response_.size(), bytes_read_from_plc);
-        return hardware_interface::return_type::ERROR;
+    hardware_interface::CallbackReturn BeckhoffADSHardwareInterface::on_deactivate(
+        const rclcpp_lifecycle::State & /*previous_state*/)
+    {
+        // TODO: send some safety commands to the PLC?
+        return CallbackReturn::SUCCESS;
     }
 
-    bool any_item_read_failed = false;
-    for (const auto& item_layout : ads_item_layouts_read_) {
-        uint32_t item_error_code;
-        memcpy(&item_error_code,
-               ads_buffer_sum_read_response_.data() + item_layout.offset_in_read_response_error,
-               sizeof(uint32_t));
-
-        if (item_error_code != ADSERR_NOERR) {
-            RCLCPP_WARN_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
-                                 "ADS Sum Read sub-op for '%s' (handle 0x%X) failed: 0x%X.",
-                                 item_layout.plc_name_symbolic.c_str(), item_layout.ads_handle, item_error_code);
-            // TODO: See if we need to do something on read error. Maybe assign NaN to the interface?
-            any_item_read_failed = true;
-            continue;
+    hardware_interface::return_type BeckhoffADSHardwareInterface::read(
+        const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+    {
+        if (num_items_read_ == 0)
+        {
+            return hardware_interface::return_type::OK;
         }
 
-        const uint8_t* ptr_plc_source_data = ads_buffer_sum_read_response_.data() + item_layout.offset_in_read_response_data;
-        double* ptr_target_hw_state_block = &hw_states_[item_layout.offset_in_ros2_control];
+        uint32_t bytes_read_from_plc = 0;
+        long ads_sum_read_error = ads_device_->ReadWriteReqEx2(
+            ADSIGRP_SUMUP_READ,
+            num_items_read_,
+            ads_buffer_sum_read_response_.size(),
+            ads_buffer_sum_read_response_.data(),
+            ads_buffer_sum_read_request_.size(),
+            ads_buffer_sum_read_request_.data(),
+            &bytes_read_from_plc);
 
-        // TODO: performance - Hoist the switch/case above for loop?
-        for (size_t k = 0; k < item_layout.num_elements; ++k) {
-            const uint8_t* ptr_plc_element_current = ptr_plc_source_data + k * item_layout.plc_element_byte_size;
-            double* ptr_target_hw_state = ptr_target_hw_state_block + k;
+        if (ads_sum_read_error != ADSERR_NOERR)
+        {
+            RCLCPP_ERROR_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
+                                  "Overall ADS Sum Read Error: 0x%lX.", ads_sum_read_error);
+            // TODO: See if we need to do something on read error. Maybe assign NaN to all interfaces?
+            return hardware_interface::return_type::ERROR;
+        }
 
-            switch (item_layout.plc_type) {
-                case PLCType::LREAL: {
+        if (bytes_read_from_plc != ads_buffer_sum_read_response_.size())
+        {
+            RCLCPP_ERROR_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
+                                  "ADS Sum Read size mismatch. Expected %zu, Got %u.",
+                                  ads_buffer_sum_read_response_.size(), bytes_read_from_plc);
+            return hardware_interface::return_type::ERROR;
+        }
+
+        bool any_item_read_failed = false;
+        for (const auto &item_layout : ads_item_layouts_read_)
+        {
+            uint32_t item_error_code;
+            memcpy(&item_error_code,
+                   ads_buffer_sum_read_response_.data() + item_layout.offset_in_read_response_error,
+                   sizeof(uint32_t));
+
+            if (item_error_code != ADSERR_NOERR)
+            {
+                RCLCPP_WARN_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
+                                     "ADS Sum Read sub-op for '%s' (handle 0x%X) failed: 0x%X.",
+                                     item_layout.plc_name_symbolic.c_str(), item_layout.ads_handle, item_error_code);
+                // TODO: See if we need to do something on read error. Maybe assign NaN to the interface?
+                any_item_read_failed = true;
+                continue;
+            }
+
+            const uint8_t *ptr_plc_source_data = ads_buffer_sum_read_response_.data() + item_layout.offset_in_read_response_data;
+
+            // TODO: performance - Hoist the switch/case above for loop?
+            for (size_t k = 0; k < item_layout.num_elements; ++k)
+            {
+                const uint8_t *ptr_plc_element_current = ptr_plc_source_data + k * item_layout.plc_element_byte_size;
+
+                switch (item_layout.plc_type)
+                {
+                case PLCType::LREAL:
+                {
                     double val;
                     memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    *ptr_target_hw_state = val;
+                    set_state(item_layout.ros2_interfaces_.find(k)->second, val);
                     break;
                 }
-                case PLCType::REAL: {
+                case PLCType::REAL:
+                {
                     float val;
                     memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    *ptr_target_hw_state = static_cast<double>(val);
+                    set_state(item_layout.ros2_interfaces_.find(k)->second, static_cast<double>(val));
                     break;
                 }
-                case PLCType::BOOL: {
+                case PLCType::BOOL:
+                {
                     uint8_t byte_val;
                     memcpy(&byte_val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    *ptr_target_hw_state = (byte_val != 0) ? 1.0 : 0.0;
+                    set_state(item_layout.ros2_interfaces_.find(k)->second, (byte_val != 0) ? 1.0 : 0.0);
                     break;
                 }
-                case PLCType::SINT: {
+                case PLCType::SINT:
+                {
                     int8_t val;
                     memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    *ptr_target_hw_state = static_cast<double>(val);
+                    set_state(item_layout.ros2_interfaces_.find(k)->second, static_cast<double>(val));
                     break;
                 }
                 case PLCType::USINT:
-                case PLCType::BYTE: {
+                case PLCType::BYTE:
+                {
                     uint8_t val;
                     memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    *ptr_target_hw_state = static_cast<double>(val);
+                    set_state(item_layout.ros2_interfaces_.find(k)->second, static_cast<double>(val));
                     break;
                 }
-                case PLCType::INT: {
+                case PLCType::INT:
+                {
                     int16_t val;
                     memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    *ptr_target_hw_state = static_cast<double>(val);
+                    set_state(item_layout.ros2_interfaces_.find(k)->second, static_cast<double>(val));
                     break;
                 }
-                case PLCType::UINT: {
+                case PLCType::UINT:
+                {
                     uint16_t val;
                     memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    *ptr_target_hw_state = static_cast<double>(val);
+                    set_state(item_layout.ros2_interfaces_.find(k)->second, static_cast<double>(val));
                     break;
                 }
-                case PLCType::DINT: {
+                case PLCType::DINT:
+                {
                     int32_t val;
                     memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    *ptr_target_hw_state = static_cast<double>(val);
+                    set_state(item_layout.ros2_interfaces_.find(k)->second, static_cast<double>(val));
                     break;
                 }
-                case PLCType::UDINT: {
+                case PLCType::UDINT:
+                {
                     uint32_t val;
                     memcpy(&val, ptr_plc_element_current, item_layout.plc_element_byte_size);
-                    *ptr_target_hw_state = static_cast<double>(val);
+                    set_state(item_layout.ros2_interfaces_.find(k)->second, static_cast<double>(val));
                     break;
                 }
                 /* Not supported for now, guarded against in on_configure()
@@ -478,95 +505,109 @@ hardware_interface::return_type BeckhoffADSHardwareInterface::read(
                 case PLCType::UNKNOWN:
                 default:
                     RCLCPP_ERROR_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
-                                         "Unhandled or UNKNOWN PLC type (%d) for variable '%s' element %zu during read.",
-                                         static_cast<int>(item_layout.plc_type), item_layout.plc_name_symbolic.c_str(), k);
-                    *ptr_target_hw_state = std::numeric_limits<double>::quiet_NaN();
+                                          "Unhandled or UNKNOWN PLC type (%d) for variable '%s' element %zu during read.",
+                                          static_cast<int>(item_layout.plc_type), item_layout.plc_name_symbolic.c_str(), k);
+                    set_state(item_layout.ros2_interfaces_.find(k)->second, std::numeric_limits<double>::quiet_NaN());
                     any_item_read_failed = true;
                     break;
+                }
             }
-
         }
-    }
-    return any_item_read_failed ? hardware_interface::return_type::ERROR : hardware_interface::return_type::OK;
-}
-
-hardware_interface::return_type BeckhoffADSHardwareInterface::write(
-  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
-{
-    if (num_items_write_  == 0) {
-        return hardware_interface::return_type::OK;
+        return any_item_read_failed ? hardware_interface::return_type::ERROR : hardware_interface::return_type::OK;
     }
 
-    for (const auto & item_layout : ads_item_layouts_write_) {
+    hardware_interface::return_type BeckhoffADSHardwareInterface::write(
+        const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+    {
+        if (num_items_write_ == 0)
+        {
+            return hardware_interface::return_type::OK;
+        }
 
-        uint8_t* ptr_write_buffer_destination = ads_buffer_sum_write_request_.data() + item_layout.offset_in_write_request_data;
+        for (const auto &item_layout : ads_item_layouts_write_)
+        {
+            uint8_t *ptr_write_buffer_destination = ads_buffer_sum_write_request_.data() + item_layout.offset_in_write_request_data;
 
-        // TODO: performance - Hoist the switch/case above for loop?
-        for (size_t k = 0; k < item_layout.num_elements; ++k) {
+            // TODO: performance - Hoist the switch/case above for loop?
+            for (size_t k = 0; k < item_layout.num_elements; ++k)
+            {
+                // store the current val and reset the ros-side command value
+                double val = get_command(item_layout.ros2_interfaces_.find(k)->second);
+                set_command(item_layout.ros2_interfaces_.find(k)->second, std::numeric_limits<double>::quiet_NaN());
 
-            // store the current val and reset the ros-side command value
-            double val = hw_commands_[ item_layout.offset_in_ros2_control + k ];
-            hw_commands_[ item_layout.offset_in_ros2_control + k ] = std::numeric_limits<double>::quiet_NaN();
+                if (std::isnan(val))
+                {
+                    // if the original value was NaN and there exist a state interface of the same name, write corresponding state interface
+                    if (!item_layout.state_command_interfaces_map_.empty())
+                    {
+                        std::string current_command_interface_name = item_layout.ros2_interfaces_.find(k)->second;
+                        val = get_state(item_layout.state_command_interfaces_map_.find(current_command_interface_name)->second);
+                    }
 
-            if(std::isnan(val)){
-                // if the original value was NaN and there exist a state interface of the same name, write corresponding state interface
-                if (item_layout.offset_in_ros2_control_state_ != std::numeric_limits<size_t>::max()){
-                    val = hw_states_[item_layout.offset_in_ros2_control_state_ + k];
+                    // if we STILL don't have a fallback value on, don't update the write buffer.
+                    // the last valid command is written
+                    if (std::isnan(val))
+                    {
+                        continue;
+                    }
                 }
 
-                // if we STILL don't have a fallback value on, don't update the write buffer.
-                // the last valid command is written
-                if (std::isnan(val)) {
-                    continue;
-                }
-            }
+                uint8_t *ptr_write_buffer_destination_current = ptr_write_buffer_destination + (k * item_layout.plc_element_byte_size);
 
-            uint8_t* ptr_write_buffer_destination_current = ptr_write_buffer_destination + (k * item_layout.plc_element_byte_size);
-
-            switch (item_layout.plc_type) {
-                case PLCType::LREAL: {
+                switch (item_layout.plc_type)
+                {
+                case PLCType::LREAL:
+                {
                     // val is already double (LREAL is 8 bytes - 64 bit)
                     memcpy(ptr_write_buffer_destination_current, &val, item_layout.plc_element_byte_size);
                     break;
                 }
-                case PLCType::REAL: {
+                case PLCType::REAL:
+                {
                     float plc_val = static_cast<float>(val);
                     memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
                     break;
                 }
-                case PLCType::BOOL: {
+                case PLCType::BOOL:
+                {
                     // bool is size of byte in PLC
-                    uint8_t plc_val = (val!= 0.0)? 1 : 0;
+                    uint8_t plc_val = (val != 0.0) ? 1 : 0;
                     memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
                     break;
                 }
-                case PLCType::SINT: {
+                case PLCType::SINT:
+                {
                     int8_t plc_val = static_cast<int8_t>(std::round(val));
                     memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
                     break;
                 }
                 case PLCType::USINT:
-                case PLCType::BYTE: {
+                case PLCType::BYTE:
+                {
                     uint8_t plc_val = static_cast<uint8_t>(std::round(val));
                     memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
                     break;
                 }
-                case PLCType::INT: {
+                case PLCType::INT:
+                {
                     int16_t plc_val = static_cast<int16_t>(std::round(val));
                     memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
                     break;
                 }
-                case PLCType::UINT: {
+                case PLCType::UINT:
+                {
                     uint16_t plc_val = static_cast<uint16_t>(std::round(val));
                     memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
                     break;
                 }
-                case PLCType::DINT: {
+                case PLCType::DINT:
+                {
                     int32_t plc_val = static_cast<int32_t>(std::round(val));
                     memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
                     break;
                 }
-                case PLCType::UDINT: {
+                case PLCType::UDINT:
+                {
                     uint32_t plc_val = static_cast<uint32_t>(std::round(val));
                     memcpy(ptr_write_buffer_destination_current, &plc_val, item_layout.plc_element_byte_size);
                     break;
@@ -577,159 +618,193 @@ hardware_interface::return_type BeckhoffADSHardwareInterface::write(
                 case PLCType::UNKNOWN:
                 default:
                     RCLCPP_FATAL(getLogger(), "UNKNOWN PLC type (%d) for variable '%s' element %zu during write. Sending zeroed data of size %zu.",
-                    static_cast<int>(item_layout.plc_type), item_layout.plc_name_symbolic.c_str(), k, item_layout.plc_element_byte_size);
+                                 static_cast<int>(item_layout.plc_type), item_layout.plc_name_symbolic.c_str(), k, item_layout.plc_element_byte_size);
                     return hardware_interface::return_type::ERROR;
                     break;
+                }
             }
         }
-    }
 
-    uint32_t bytes_response_buffer_from_plc = 0;
-    long ads_sum_write_error = ads_device_->ReadWriteReqEx2(
-        ADSIGRP_SUMUP_WRITE,
-        num_items_write_,
-        ads_buffer_sum_write_response_.size(),
-        ads_buffer_sum_write_response_.data(),
-        ads_buffer_sum_write_request_.size(),
-        ads_buffer_sum_write_request_.data(),
-        &bytes_response_buffer_from_plc
-    );
+        uint32_t bytes_response_buffer_from_plc = 0;
+        long ads_sum_write_error = ads_device_->ReadWriteReqEx2(
+            ADSIGRP_SUMUP_WRITE,
+            num_items_write_,
+            ads_buffer_sum_write_response_.size(),
+            ads_buffer_sum_write_response_.data(),
+            ads_buffer_sum_write_request_.size(),
+            ads_buffer_sum_write_request_.data(),
+            &bytes_response_buffer_from_plc);
 
-    if (ads_sum_write_error != ADSERR_NOERR) {
-        RCLCPP_ERROR_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
-                              "Overall ADS Sum Write Error: 0x%lX.", ads_sum_write_error);
-        return hardware_interface::return_type::ERROR;
-    }
-
-    if (bytes_response_buffer_from_plc != ads_buffer_sum_write_response_.size()) {
-         RCLCPP_ERROR_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
-                              "ADS Sum Write response size mismatch (error codes). Expected %zu, Got %u.",
-                              ads_buffer_sum_write_response_.size(), bytes_response_buffer_from_plc);
-    }
-
-    bool any_item_write_failed = false;
-    for (size_t i = 0; i < num_items_write_; ++i) {
-        uint32_t item_error_code;
-        memcpy(&item_error_code, ads_buffer_sum_write_response_.data() + i * sizeof(uint32_t), sizeof(uint32_t));
-        if (item_error_code != ADSERR_NOERR) {
-            RCLCPP_WARN_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
-                                 "ADS Sum Write sub-op for '%s' (handle 0x%X) failed: 0x%X",
-                                 ads_item_layouts_write_[i].plc_name_symbolic.c_str(), ads_item_layouts_write_[i].ads_handle, item_error_code);
-            any_item_write_failed = true;
-        }
-    }
-
-    return any_item_write_failed ? hardware_interface::return_type::ERROR : hardware_interface::return_type::OK;
-}
-
-
-hardware_interface::CallbackReturn BeckhoffADSHardwareInterface::on_shutdown(
-    const rclcpp_lifecycle::State & /*previous_state*/)
-{
-    RCLCPP_INFO(getLogger(), "Releasing ADS resources...");
-    if (ads_device_) {
-        ads_device_.reset();
-    }
-    RCLCPP_INFO(getLogger(), "ADS resources released.");
-
-    return hardware_interface::CallbackReturn::SUCCESS;
-}
-
-bool BeckhoffADSHardwareInterface::configure_ads_device()
-{
-    RCLCPP_INFO(getLogger(), "Configuring ADS device...");
-    const auto & params = info_.hardware_parameters;
-    try {
-        std::string plc_ip = params.at("plc_ip_address");
-        std::string plc_ams_net_id_str = params.at("plc_ams_net_id");
-        std::string local_ams_net_id_str = params.at("local_ams_net_id");
-        uint16_t plc_ams_port = std::stoul(params.at("plc_ams_port"));
-
-        AmsNetId remote_net_id;
-        if (sscanf(plc_ams_net_id_str.c_str(), "%hhu.%hhu.%hhu.%hhu.%hhu.%hhu",
-            &remote_net_id.b[0], &remote_net_id.b[1], &remote_net_id.b[2],
-            &remote_net_id.b[3], &remote_net_id.b[4], &remote_net_id.b[5]) != 6)
+        if (ads_sum_write_error != ADSERR_NOERR)
         {
-             RCLCPP_FATAL(getLogger(), "\tInvalid format for 'plc_ams_net_id'. Expected 'x.x.x.x.x.x'.");
-             return false;
+            RCLCPP_ERROR_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
+                                  "Overall ADS Sum Write Error: 0x%lX.", ads_sum_write_error);
+            return hardware_interface::return_type::ERROR;
         }
 
-        AmsNetId local_net_id;
-        if (sscanf(local_ams_net_id_str.c_str(), "%hhu.%hhu.%hhu.%hhu.%hhu.%hhu",
-            &local_net_id.b[0], &local_net_id.b[1], &local_net_id.b[2],
-            &local_net_id.b[3], &local_net_id.b[4], &local_net_id.b[5]) != 6)
+        if (bytes_response_buffer_from_plc != ads_buffer_sum_write_response_.size())
         {
-             RCLCPP_FATAL(getLogger(), "\tInvalid format for 'local_ams_net_id'. Expected 'x.x.x.x.x.x'.");
-             return false;
+            RCLCPP_ERROR_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
+                                  "ADS Sum Write response size mismatch (error codes). Expected %zu, Got %u.",
+                                  ads_buffer_sum_write_response_.size(), bytes_response_buffer_from_plc);
         }
 
-        bhf::ads::SetLocalAddress(local_net_id);
-        ads_device_ = std::make_unique<AdsDevice>(plc_ip, remote_net_id, plc_ams_port);
+        bool any_item_write_failed = false;
+        for (size_t i = 0; i < num_items_write_; ++i)
+        {
+            uint32_t item_error_code;
+            memcpy(&item_error_code, ads_buffer_sum_write_response_.data() + i * sizeof(uint32_t), sizeof(uint32_t));
+            if (item_error_code != ADSERR_NOERR)
+            {
+                RCLCPP_WARN_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
+                                     "ADS Sum Write sub-op for '%s' (handle 0x%X) failed: 0x%X",
+                                     ads_item_layouts_write_[i].plc_name_symbolic.c_str(), ads_item_layouts_write_[i].ads_handle, item_error_code);
+                any_item_write_failed = true;
+            }
+        }
 
-        RCLCPP_INFO(getLogger(), "\tADS Device configured for PLC: %s, Port: %u", plc_ip.c_str(), plc_ams_port);
-        RCLCPP_INFO(getLogger(), "\tPLC AMS NetID: %s", plc_ams_net_id_str.c_str());
-
-        RCLCPP_INFO(getLogger(), "Requesting Device state...");
-        AdsDeviceState deviceState = ads_device_->GetState();
-        RCLCPP_INFO(getLogger(), "\tCommunication successful! ADS State: %d, DeviceState: %d", deviceState.ads, deviceState.device);
-
-    } catch (const std::out_of_range & ex) {
-        RCLCPP_FATAL(getLogger(), "\tMissing required URDF <hardware> parameter: %s", ex.what());
-        return false;
-    } catch (const AdsException & ex) {
-        RCLCPP_FATAL(getLogger(), "\tADS Exception during connection: %s (Error Code: 0x%lX)", ex.what(), ex.errorCode);
-        return false;
-    } catch (const std::exception & ex) {
-        RCLCPP_FATAL(getLogger(), "\tError during ADS connection config: %s", ex.what());
-        return false;
+        return any_item_write_failed ? hardware_interface::return_type::ERROR : hardware_interface::return_type::OK;
     }
 
-    return true;
-}
+    hardware_interface::CallbackReturn BeckhoffADSHardwareInterface::on_shutdown(
+        const rclcpp_lifecycle::State & /*previous_state*/)
+    {
+        RCLCPP_INFO(getLogger(), "Releasing ADS resources...");
+        if (ads_device_)
+        {
+            ads_device_.reset();
+        }
+        RCLCPP_INFO(getLogger(), "ADS resources released.");
 
-PLCType BeckhoffADSHardwareInterface::strToPlcType(const std::string& type_str_param) {
-    std::string type_str = type_str_param;
-    std::transform(type_str.begin(), type_str.end(), type_str.begin(), ::toupper);
+        return hardware_interface::CallbackReturn::SUCCESS;
+    }
 
-    if (type_str == "LREAL") return PLCType::LREAL;
-    if (type_str == "REAL") return PLCType::REAL;
-    if (type_str == "BOOL") return PLCType::BOOL;
-    if (type_str == "UDINT") return PLCType::UDINT;
-    if (type_str == "DINT") return PLCType::DINT;
-    if (type_str == "UINT") return PLCType::UINT;
-    if (type_str == "INT") return PLCType::INT;
-    if (type_str == "USINT") return PLCType::USINT;
-    if (type_str == "SINT") return PLCType::SINT;
-    if (type_str == "BYTE") return PLCType::BYTE;
-    if (type_str == "STRING") return PLCType::STRING;
+    bool BeckhoffADSHardwareInterface::configure_ads_device()
+    {
+        RCLCPP_INFO(getLogger(), "Configuring ADS device...");
+        const auto &params = info_.hardware_parameters;
+        try
+        {
+            std::string plc_ip = params.at("plc_ip_address");
+            std::string plc_ams_net_id_str = params.at("plc_ams_net_id");
+            std::string local_ams_net_id_str = params.at("local_ams_net_id");
+            uint16_t plc_ams_port = std::stoul(params.at("plc_ams_port"));
 
-    RCLCPP_ERROR(getLogger(), "Unknown PLC type string: '%s'", type_str_param.c_str());
-    return PLCType::UNKNOWN;
-}
+            AmsNetId remote_net_id;
+            if (sscanf(plc_ams_net_id_str.c_str(), "%hhu.%hhu.%hhu.%hhu.%hhu.%hhu",
+                       &remote_net_id.b[0], &remote_net_id.b[1], &remote_net_id.b[2],
+                       &remote_net_id.b[3], &remote_net_id.b[4], &remote_net_id.b[5]) != 6)
+            {
+                RCLCPP_FATAL(getLogger(), "\tInvalid format for 'plc_ams_net_id'. Expected 'x.x.x.x.x.x'.");
+                return false;
+            }
 
-size_t BeckhoffADSHardwareInterface::plcTypeByteSize(PLCType plc_type_enum) {
-    switch (plc_type_enum) {
-        case PLCType::LREAL: return 8;
-        case PLCType::REAL:  return 4;
-        case PLCType::BOOL:  return 1;
-        case PLCType::UDINT: return 4;
-        case PLCType::DINT:  return 4;
-        case PLCType::UINT:  return 2;
-        case PLCType::INT:   return 2;
-        case PLCType::USINT: return 1;
-        case PLCType::SINT:  return 1;
-        case PLCType::BYTE:  return 1;
-        //case PLCType::STRING: not currently supported
-        case PLCType::UNKNOWN: default:
+            AmsNetId local_net_id;
+            if (sscanf(local_ams_net_id_str.c_str(), "%hhu.%hhu.%hhu.%hhu.%hhu.%hhu",
+                       &local_net_id.b[0], &local_net_id.b[1], &local_net_id.b[2],
+                       &local_net_id.b[3], &local_net_id.b[4], &local_net_id.b[5]) != 6)
+            {
+                RCLCPP_FATAL(getLogger(), "\tInvalid format for 'local_ams_net_id'. Expected 'x.x.x.x.x.x'.");
+                return false;
+            }
+
+            bhf::ads::SetLocalAddress(local_net_id);
+            ads_device_ = std::make_unique<AdsDevice>(plc_ip, remote_net_id, plc_ams_port);
+            RCLCPP_INFO(getLogger(), "\tTimeout is: %u", ads_device_->GetTimeout());
+
+            RCLCPP_INFO(getLogger(), "\tADS Device configured for PLC: %s, Port: %u", plc_ip.c_str(), plc_ams_port);
+            RCLCPP_INFO(getLogger(), "\tPLC AMS NetID: %s", plc_ams_net_id_str.c_str());
+
+            RCLCPP_INFO(getLogger(), "Requesting Device state...");
+            AdsDeviceState deviceState = ads_device_->GetState();
+            RCLCPP_INFO(getLogger(), "\tCommunication successful! ADS State: %d, DeviceState: %d", deviceState.ads, deviceState.device);
+        }
+        catch (const std::out_of_range &ex)
+        {
+            RCLCPP_FATAL(getLogger(), "\tMissing required URDF <hardware> parameter: %s", ex.what());
+            return false;
+        }
+        catch (const AdsException &ex)
+        {
+            RCLCPP_FATAL(getLogger(), "\tADS Exception during connection: %s (Error Code: 0x%lX)", ex.what(), ex.errorCode);
+            return false;
+        }
+        catch (const std::exception &ex)
+        {
+            RCLCPP_FATAL(getLogger(), "\tError during ADS connection config: %s", ex.what());
+            return false;
+        }
+
+        return true;
+    }
+
+    PLCType BeckhoffADSHardwareInterface::strToPlcType(const std::string &type_str_param)
+    {
+        std::string type_str = type_str_param;
+        std::transform(type_str.begin(), type_str.end(), type_str.begin(), ::toupper);
+
+        if (type_str == "LREAL")
+            return PLCType::LREAL;
+        if (type_str == "REAL")
+            return PLCType::REAL;
+        if (type_str == "BOOL")
+            return PLCType::BOOL;
+        if (type_str == "UDINT")
+            return PLCType::UDINT;
+        if (type_str == "DINT")
+            return PLCType::DINT;
+        if (type_str == "UINT")
+            return PLCType::UINT;
+        if (type_str == "INT")
+            return PLCType::INT;
+        if (type_str == "USINT")
+            return PLCType::USINT;
+        if (type_str == "SINT")
+            return PLCType::SINT;
+        if (type_str == "BYTE")
+            return PLCType::BYTE;
+        if (type_str == "STRING")
+            return PLCType::STRING;
+
+        RCLCPP_ERROR(getLogger(), "Unknown PLC type string: '%s'", type_str_param.c_str());
+        return PLCType::UNKNOWN;
+    }
+
+    size_t BeckhoffADSHardwareInterface::plcTypeByteSize(PLCType plc_type_enum)
+    {
+        switch (plc_type_enum)
+        {
+        case PLCType::LREAL:
+            return 8;
+        case PLCType::REAL:
+            return 4;
+        case PLCType::BOOL:
+            return 1;
+        case PLCType::UDINT:
+            return 4;
+        case PLCType::DINT:
+            return 4;
+        case PLCType::UINT:
+            return 2;
+        case PLCType::INT:
+            return 2;
+        case PLCType::USINT:
+            return 1;
+        case PLCType::SINT:
+            return 1;
+        case PLCType::BYTE:
+            return 1;
+        // case PLCType::STRING: not currently supported
+        case PLCType::UNKNOWN:
+        default:
             RCLCPP_ERROR(getLogger(), "Cannot get byte size for UNKNOWN or unhandled PLC type enum value: %d", static_cast<int>(plc_type_enum));
             return 0;
+        }
     }
-}
 
-
-}  // namespace beckhoff_ads_hardware_interface
+} // namespace beckhoff_ads_hardware_interface
 
 #include "pluginlib/class_list_macros.hpp"
 
 PLUGINLIB_EXPORT_CLASS(
-  beckhoff_ads_hardware_interface::BeckhoffADSHardwareInterface, hardware_interface::SystemInterface)
+    beckhoff_ads_hardware_interface::BeckhoffADSHardwareInterface, hardware_interface::SystemInterface)

--- a/beckhoff_ads_hardware_interface/src/beckhoff_ads_hardware_interface.cpp
+++ b/beckhoff_ads_hardware_interface/src/beckhoff_ads_hardware_interface.cpp
@@ -7,6 +7,7 @@
 // The file is considered confidential.
 //
 // Author: Nikola Banovic
+// Contributor: Hajar Bartakh
 
 #include <limits>
 #include <vector>
@@ -140,10 +141,10 @@ namespace beckhoff_ads_hardware_interface
             {
                 // Fill the read instruction vector
                 ReadInstruction read_instruction;
-                read_instruction.read_error_code_offset = layout.offset_in_read_response_error;
-                read_instruction.buffer_offset = layout.offset_in_read_response_data + index * layout.plc_element_byte_size;
+                read_instruction.read_buffer_offset_error_code = layout.offset_in_read_response_error;
+                read_instruction.read_buffer_offset_data = layout.offset_in_read_response_data + index * layout.plc_element_byte_size;
                 read_instruction.plc_type = layout.plc_type;
-                read_instruction.interface_name = interface_name;
+                read_instruction.state_interface_name = interface_name;
 
                 // The state interfaces' names are ordered by ascending indexes of the PLC array thanks to layout.ros2_interfaces_ being a map
                 ads_read_instructions_.push_back(read_instruction);
@@ -194,15 +195,15 @@ namespace beckhoff_ads_hardware_interface
             {
                 // Fill the write instruction vector
                 WriteInstruction write_instruction;
-                write_instruction.buffer_offset = layout.offset_in_write_request_data + index * layout.plc_element_byte_size;
+                write_instruction.write_buffer_offset_data = layout.offset_in_write_request_data + index * layout.plc_element_byte_size;
                 write_instruction.plc_type = layout.plc_type;
-                write_instruction.interface_name = interface_name;
-                write_instruction.fallback_name = "";
+                write_instruction.command_interface_name = interface_name;
+                write_instruction.fallback_state_interface_name = "";
 
                 // There exists a state interface for the same PLC symbol
                 if (!layout.state_command_interfaces_map_.empty())
                 {
-                    write_instruction.fallback_name = layout.state_command_interfaces_map_.find(interface_name)->second;
+                    write_instruction.fallback_state_interface_name = layout.state_command_interfaces_map_.find(interface_name)->second;
                 }
 
                 // The command interfaces' names are ordered by ascending indexes of the PLC array thanks to layout.ros2_interfaces_ being a map
@@ -447,14 +448,14 @@ namespace beckhoff_ads_hardware_interface
         {
             uint32_t item_error_code;
             memcpy(&item_error_code,
-                   ads_buffer_sum_read_response_.data() + read_instruction.read_error_code_offset,
+                   ads_buffer_sum_read_response_.data() + read_instruction.read_buffer_offset_error_code,
                    sizeof(uint32_t));
 
             if (item_error_code != ADSERR_NOERR)
             {
                 RCLCPP_WARN_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
                                      "ADS Sum Read operation corresponding to the state interface '%s' failed: 0x%X.",
-                                     read_instruction.interface_name.c_str(), item_error_code);
+                                     read_instruction.state_interface_name.c_str(), item_error_code);
 
                 // TODO: See if we need to do something on read error. Maybe assign NaN to the interface?
                 any_item_read_failed = true;
@@ -462,7 +463,7 @@ namespace beckhoff_ads_hardware_interface
             }
 
             // Each state interface has its corresponding read_instruction
-            const uint8_t *ptr_plc_element_current = ads_buffer_sum_read_response_.data() + read_instruction.buffer_offset;
+            const uint8_t *ptr_plc_element_current = ads_buffer_sum_read_response_.data() + read_instruction.read_buffer_offset_data;
 
             // TODO: performance - Hoist the switch/case above for loop?
 
@@ -472,28 +473,28 @@ namespace beckhoff_ads_hardware_interface
             {
                 double val;
                 memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
-                set_state(read_instruction.interface_name, val);
+                set_state(read_instruction.state_interface_name, val);
                 break;
             }
             case PLCType::REAL:
             {
                 float val;
                 memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
-                set_state(read_instruction.interface_name, static_cast<double>(val));
+                set_state(read_instruction.state_interface_name, static_cast<double>(val));
                 break;
             }
             case PLCType::BOOL:
             {
                 uint8_t byte_val;
                 memcpy(&byte_val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
-                set_state(read_instruction.interface_name, (byte_val != 0) ? 1.0 : 0.0);
+                set_state(read_instruction.state_interface_name, (byte_val != 0) ? 1.0 : 0.0);
                 break;
             }
             case PLCType::SINT:
             {
                 int8_t val;
                 memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
-                set_state(read_instruction.interface_name, static_cast<double>(val));
+                set_state(read_instruction.state_interface_name, static_cast<double>(val));
                 break;
             }
             case PLCType::USINT:
@@ -501,35 +502,35 @@ namespace beckhoff_ads_hardware_interface
             {
                 uint8_t val;
                 memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
-                set_state(read_instruction.interface_name, static_cast<double>(val));
+                set_state(read_instruction.state_interface_name, static_cast<double>(val));
                 break;
             }
             case PLCType::INT:
             {
                 int16_t val;
                 memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
-                set_state(read_instruction.interface_name, static_cast<double>(val));
+                set_state(read_instruction.state_interface_name, static_cast<double>(val));
                 break;
             }
             case PLCType::UINT:
             {
                 uint16_t val;
                 memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
-                set_state(read_instruction.interface_name, static_cast<double>(val));
+                set_state(read_instruction.state_interface_name, static_cast<double>(val));
                 break;
             }
             case PLCType::DINT:
             {
                 int32_t val;
                 memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
-                set_state(read_instruction.interface_name, static_cast<double>(val));
+                set_state(read_instruction.state_interface_name, static_cast<double>(val));
                 break;
             }
             case PLCType::UDINT:
             {
                 uint32_t val;
                 memcpy(&val, ptr_plc_element_current, plcTypeByteSize(read_instruction.plc_type));
-                set_state(read_instruction.interface_name, static_cast<double>(val));
+                set_state(read_instruction.state_interface_name, static_cast<double>(val));
                 break;
             }
             /* Not supported for now, guarded against in on_configure()
@@ -540,8 +541,8 @@ namespace beckhoff_ads_hardware_interface
             default:
                 RCLCPP_ERROR_THROTTLE(getLogger(), *logging_throttle_clock_, 1000,
                                       "Unhandled or UNKNOWN PLC type (%d) for the interface '%s' during read.",
-                                      static_cast<int>(read_instruction.plc_type), read_instruction.interface_name.c_str());
-                set_state(read_instruction.interface_name, std::numeric_limits<double>::quiet_NaN());
+                                      static_cast<int>(read_instruction.plc_type), read_instruction.state_interface_name.c_str());
+                set_state(read_instruction.state_interface_name, std::numeric_limits<double>::quiet_NaN());
                 any_item_read_failed = true;
                 break;
             }
@@ -559,20 +560,20 @@ namespace beckhoff_ads_hardware_interface
 
         for (const auto &write_instruction : ads_write_instructions_)
         {
-            uint8_t *ptr_write_buffer_destination_current = ads_buffer_sum_write_request_.data() + write_instruction.buffer_offset;
+            uint8_t *ptr_write_buffer_destination_current = ads_buffer_sum_write_request_.data() + write_instruction.write_buffer_offset_data;
 
             // TODO: performance - Hoist the switch/case above for loop?
 
             // store the current val and reset the ros-side command value
-            double val = get_command(write_instruction.interface_name);
-            set_command(write_instruction.interface_name, std::numeric_limits<double>::quiet_NaN());
+            double val = get_command(write_instruction.command_interface_name);
+            set_command(write_instruction.command_interface_name, std::numeric_limits<double>::quiet_NaN());
 
             if (std::isnan(val))
             {
                 // if the original value was NaN and there exist a state interface of the same name, write corresponding state interface
-                if (!write_instruction.fallback_name.empty())
+                if (!write_instruction.fallback_state_interface_name.empty())
                 {
-                    val = get_state(write_instruction.fallback_name);
+                    val = get_state(write_instruction.fallback_state_interface_name);
                 }
 
                 // if we STILL don't have a fallback value on, don't update the write buffer.
@@ -647,7 +648,7 @@ namespace beckhoff_ads_hardware_interface
             case PLCType::UNKNOWN:
             default:
                 RCLCPP_FATAL(getLogger(), "UNKNOWN PLC type (%d) for the interface '%s' during write. Sending zeroed data of size %zu.",
-                             static_cast<int>(write_instruction.plc_type), write_instruction.interface_name.c_str(), plcTypeByteSize(write_instruction.plc_type));
+                             static_cast<int>(write_instruction.plc_type), write_instruction.command_interface_name.c_str(), plcTypeByteSize(write_instruction.plc_type));
                 return hardware_interface::return_type::ERROR;
                 break;
             }


### PR DESCRIPTION
This PR is opened for versioning the code to make it easier to compare the performance of the different implementations (hw_* vectors, Layout maps and Instruction classes) of the read and write operations of the hardware interface.  



In the previous versions of ros2_control, the hardware interface owned the memory for the state and command interfaces.
Then, the changes introduced in the recent distributions of ROS2 (Jazzy, and newer) gave this ownership to the resource manager instead.

To align this hardware interface with these changes, here are the main modifications done to the code:

    Removal of on_export_state/command_interfaces methods. The logic related to the ADS protocol was moved to separate functions configure_ads_read and configure_ads_write.
    Removal of hw_state and hw_command vectors.
    Use of setters and getters to access state and command interfaces.
    Addition of the attribute ros2_interfaces_ to ADSDataLayout to store the names of the interfaces targeting the same PLC symbol of type ARRAY[x].
    Addition of the attribute state_command_interfaces_map_ to ADSDataLayout that maps the command interfaces names to their corresponding state interfaces if they exist. Storing the interfaces' full names is useful when calling the set/get_command and set/get_state functions.

