### PR TITLE
Keep ADS symbol handles alive for the layout lifetime

### DIFF
--- a/beckhoff_ads_hardware_interface/include/beckhoff_ads_hardware_interface/beckhoff_ads_hardware_interface.hpp
+++ b/beckhoff_ads_hardware_interface/include/beckhoff_ads_hardware_interface/beckhoff_ads_hardware_interface.hpp
@@ -12,6 +12,7 @@
 #ifndef beckhoff_ads_hardware_interface__BECKHOFF_SYSTEM_HPP_
 #define beckhoff_ads_hardware_interface__BECKHOFF_SYSTEM_HPP_
 
+#include <optional>
 #include <string>
 #include <vector>
 #include <limits>
@@ -51,7 +52,8 @@ namespace beckhoff_ads_hardware_interface
     // Configured from yaml
     std::string plc_name_symbolic; // e.g., "MAIN.Joint_Pos_State". Used to get the handle.
     PLCType plc_type;
-    uint32_t ads_handle; // PLC Handle for the symbolic name. Not using AdsHandle, as we don't need a shared ptr, just a value to paste in the message
+    std::optional<AdsHandle> ads_handle_owner; // RAII owner; releases SYM_HNDBYNAME on destruction. Must outlive any use of ads_handle.
+    uint32_t ads_handle; // PLC Handle value cached for the sum-request headers. Mirrors **ads_handle_owner.
 
     size_t num_elements;          // 6 for LREAL[6], 1 for single LREAL/BOOL etc.
     size_t plc_element_byte_size; // byte size of ONE element on PLC (e.g., 8 for LREAL, 1 for BOOL).

--- a/beckhoff_ads_hardware_interface/src/beckhoff_ads_hardware_interface.cpp
+++ b/beckhoff_ads_hardware_interface/src/beckhoff_ads_hardware_interface.cpp
@@ -48,7 +48,8 @@ namespace beckhoff_ads_hardware_interface
         {
             try
             {
-                layout.ads_handle = *(ads_device_->GetHandle(layout.plc_name_symbolic));
+                layout.ads_handle_owner.emplace(ads_device_->GetHandle(layout.plc_name_symbolic));
+                layout.ads_handle = **layout.ads_handle_owner;
             }
             catch (const std::exception &ex)
             {
@@ -59,7 +60,8 @@ namespace beckhoff_ads_hardware_interface
         {
             try
             {
-                layout.ads_handle = *(ads_device_->GetHandle(layout.plc_name_symbolic));
+                layout.ads_handle_owner.emplace(ads_device_->GetHandle(layout.plc_name_symbolic));
+                layout.ads_handle = **layout.ads_handle_owner;
             }
             catch (const std::exception &ex)
             {
@@ -276,7 +278,7 @@ namespace beckhoff_ads_hardware_interface
                     else
                     {
                         layout.plc_element_byte_size = plcTypeByteSize(layout.plc_type);
-                        ads_item_layouts_read_.push_back(layout);
+                        ads_item_layouts_read_.push_back(std::move(layout));
                         processed_plc_symbols[plc_symbol] = true;
                     }
                 }
@@ -285,7 +287,7 @@ namespace beckhoff_ads_hardware_interface
                 {
                     // Find the ADS Data Layout object of the corresponding PLC symbol
                     auto it = std::find_if(ads_item_layouts_read_.begin(), ads_item_layouts_read_.end(),
-                                           [&plc_symbol](ADSDataLayout layout)
+                                           [&plc_symbol](const ADSDataLayout &layout)
                                            { return layout.plc_name_symbolic == plc_symbol; });
 
                     // Add the interface name the layout
@@ -374,7 +376,7 @@ namespace beckhoff_ads_hardware_interface
                     else
                     {
                         layout.plc_element_byte_size = plcTypeByteSize(layout.plc_type);
-                        ads_item_layouts_write_.push_back(layout);
+                        ads_item_layouts_write_.push_back(std::move(layout));
                         processed_plc_symbols[plc_symbol] = true;
                     }
                 }
@@ -383,7 +385,7 @@ namespace beckhoff_ads_hardware_interface
                 {
                     // Look for the ADS Data Layout of the corresponding PLC symbol
                     auto it = std::find_if(ads_item_layouts_write_.begin(), ads_item_layouts_write_.end(),
-                                           [&plc_symbol](ADSDataLayout layout)
+                                           [&plc_symbol](const ADSDataLayout &layout)
                                            { return layout.plc_name_symbolic == plc_symbol; });
 
                     // Add the command interface name the layout


### PR DESCRIPTION
## Summary

- Store the AdsHandle returned by GetHandle(symbolName) on ADSDataLayout so its destructor only runs when the layout is destroyed, not at the end of the configure statement.
- Cache the dereferenced uint32_t alongside the owner for the sum-request headers.

Fixes #10.